### PR TITLE
Remove unnecessary prints

### DIFF
--- a/graphinglib/multifigure.py
+++ b/graphinglib/multifigure.py
@@ -248,9 +248,7 @@ class SubFigure:
         if self._elements:
             z_order = 0
             for element in self._elements:
-                print(f"color before: {element.color}")
                 self._fill_in_missing_params(element)
-                print(f"color after: {element.color}")
                 element._plot_element(self._axes, z_order)
                 try:
                     if element._label is not None:


### PR DESCRIPTION
## PR summary

Fixes bug where print statements prevented certain objects from being plotted in Multifigure.

## PR checklist

- [x] Links to the related issue (#....)
- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete and documentation modified
- [x] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [x] If new files have been added, make sure they aren't excluded by .gitignore
- [x] Any new data files have been added to manifest.in
