### PR TITLE
Removed label calls for the residual curves

### DIFF
--- a/graphinglib/fits.py
+++ b/graphinglib/fits.py
@@ -221,7 +221,6 @@ class GeneralFit(Curve):
             axes.plot(
                 self.x_data,
                 y_fit_minus_std,
-                label=self.label,
                 color=self.res_color,
                 linewidth=self.res_line_width,
                 linestyle=self.res_line_style,
@@ -230,7 +229,6 @@ class GeneralFit(Curve):
             axes.plot(
                 self.x_data,
                 y_fit_plus_std,
-                label=self.label,
                 color=self.res_color,
                 linewidth=self.res_line_width,
                 linestyle=self.res_line_style,


### PR DESCRIPTION
## PR summary
Removed label parameter calls in the residual curves. Closes #241 

## PR checklist

- [x] Links to the related issue (#....)
- [x] Units tests have been run and/or modified and/or added
- [ ] Docstrings are complete and documentation modified
- [ ] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [ ] If new files have been added, make sure they aren't excluded by .gitignore
- [ ] Any new data files have been added to manifest.in
