### PR TITLE
Replaced _label and _handle by label and handle

### DIFF
--- a/graphinglib/figure.py
+++ b/graphinglib/figure.py
@@ -246,8 +246,8 @@ class Figure:
                 element._plot_element(self._axes, z_order)
                 self._reset_params_to_default(element, params_to_reset)
                 try:
-                    if element._label is not None:
-                        self._handles.append(element._handle)
+                    if element.label is not None:
+                        self._handles.append(element.handle)
                 except AttributeError:
                     continue
                 z_order += 2

--- a/graphinglib/multifigure.py
+++ b/graphinglib/multifigure.py
@@ -284,8 +284,8 @@ class SubFigure:
                 element._plot_element(self._axes, z_order)
                 self._reset_params_to_default(element, params_to_reset)
                 try:
-                    if element._label is not None:
-                        self._handles.append(element._handle)
+                    if element.label is not None:
+                        self._handles.append(element.handle)
                 except AttributeError:
                     continue
                 z_order += 2


### PR DESCRIPTION
## PR summary
The element._label and element._handle don't exist in the plottable objects. They are called element.label and element.handle instead. This is what was causing an error and, in turn, making the _prepare_figure/_prepare_multifigure method to skip the z_order += 2 call. Closes #246 

## PR checklist

- [x] Links to the related issue (#....)
- [x] Units tests have been run and/or modified and/or added
- [ ] Docstrings are complete and documentation modified
- [ ] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [ ] If new files have been added, make sure they aren't excluded by .gitignore
- [ ] Any new data files have been added to manifest.in
