### PR TITLE
Added plt.close to save_figure methods

### DIFF
--- a/graphinglib/figure.py
+++ b/graphinglib/figure.py
@@ -1,11 +1,11 @@
 from typing import Literal, Optional
 
 import matplotlib.pyplot as plt
+from cycler import cycler
 from matplotlib import rcParamsDefault
 from matplotlib.collections import LineCollection
 from matplotlib.legend_handler import HandlerPatch
 from matplotlib.patches import Polygon
-from cycler import cycler
 
 from .file_manager import FileLoader, FileUpdater
 from .graph_elements import GraphingException, Plottable
@@ -308,6 +308,7 @@ class Figure:
         self._prepare_figure(legend=legend)
         plt.tight_layout()
         plt.savefig(file_name, bbox_inches="tight")
+        plt.close()
 
     def _fill_in_missing_params(self, element: Plottable) -> list[str]:
         """

--- a/graphinglib/multifigure.py
+++ b/graphinglib/multifigure.py
@@ -3,6 +3,7 @@ from typing import Literal, Optional
 from warnings import warn
 
 import matplotlib.pyplot as plt
+from cycler import cycler
 from matplotlib import rcParamsDefault
 from matplotlib.axes import Axes
 from matplotlib.collections import LineCollection
@@ -10,7 +11,6 @@ from matplotlib.gridspec import GridSpec
 from matplotlib.legend_handler import HandlerPatch
 from matplotlib.patches import Polygon
 from matplotlib.transforms import ScaledTranslation
-from cycler import cycler
 
 from .file_manager import FileLoader, FileUpdater
 from .graph_elements import GraphingException, Plottable, Text
@@ -790,6 +790,7 @@ class MultiFigure:
             legend_cols=legend_cols,
         )
         plt.savefig(file_name, bbox_inches="tight")
+        plt.close()
 
     def _fill_in_missing_params(self, element: Plottable) -> None:
         """


### PR DESCRIPTION
## PR summary

Fixed bug where figure displayed twice when calling save_figure before displaying. Closes issue #264.

## PR checklist

- [x] Links to the related issue (#....)
- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete and documentation modified
- [x] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [x] If new files have been added, make sure they aren't excluded by .gitignore
- [x] Any new data files have been added to manifest.in
