### PR TITLE
272 change location of default fetching for figure params

### DIFF
--- a/graphinglib/default_styles/horrible.yml
+++ b/graphinglib/default_styles/horrible.yml
@@ -6,6 +6,7 @@ Curve:
   errorbars_color: "same as curve"
   errorbars_line_width: "same as curve"
   cap_thickness: "same as curve"
+  fill_under_color: "same as curve"
 
 Scatter:
   face_color: 

--- a/graphinglib/default_styles/horrible.yml
+++ b/graphinglib/default_styles/horrible.yml
@@ -49,11 +49,11 @@ Figure:
   grid_alpha: 0.3
   color_cycle: ["#a1d0ff", "#730127", "#789146", "#8800ff", "#00b3a7", "#dbc00f", "#8a8a8a", "#28301c"]
 
-Multifigure:
+MultiFigure:
   size: [10, 7]
   legend_is_boxed: True
 
-Subfigure:
+SubFigure:
   legend_is_boxed: True
   ticks_are_in: True
   log_scale_x: False

--- a/graphinglib/default_styles/plain.yml
+++ b/graphinglib/default_styles/plain.yml
@@ -50,11 +50,11 @@ Figure:
   grid_alpha: 0.5
   color_cycle: ["#3e82a0", "#edb73b", "#b9503b", "#8aba4e", "#695178", "#ed893b", "#34a893", "#616161"]
 
-Multifigure:
+MultiFigure:
   size: [6.4, 4.8]
   legend_is_boxed: False
 
-Subfigure:
+SubFigure:
   legend_is_boxed: False
   ticks_are_in: True
   log_scale_x: False

--- a/graphinglib/figure.py
+++ b/graphinglib/figure.py
@@ -130,16 +130,13 @@ class Figure:
         file_loader = FileLoader(figure_style)
         self.figure_style = figure_style
         self.default_params = file_loader.load()
-        self._get_defaults_init(
-            size,
-            legend_is_boxed,
-            ticks_are_in,
-            log_scale_x,
-            log_scale_y,
-            show_grid,
-            color_cycle,
-        )
-        self.color_cycle = cycler(color=self.color_cycle)
+        self.size = size
+        self.legend_is_boxed = legend_is_boxed
+        self.ticks_are_in = ticks_are_in
+        self.log_scale_x = log_scale_x
+        self.log_scale_y = log_scale_y
+        self.show_grid = show_grid
+        self.color_cycle = color_cycle
         self._elements: list[Plottable] = []
         self._labels: list[str | None] = []
         self._handles = []
@@ -147,50 +144,6 @@ class Figure:
         self.y_axis_name = y_label
         self.x_lim = x_lim
         self.y_lim = y_lim
-        if self.show_grid:
-            self.set_grid()
-
-    def _get_defaults_init(
-        self,
-        size,
-        legend_is_boxed,
-        ticks_are_in,
-        log_scale_x,
-        log_scale_y,
-        show_grid,
-        color_cycle,
-    ) -> None:
-        params_values = {
-            "size": size,
-            "legend_is_boxed": legend_is_boxed,
-            "ticks_are_in": ticks_are_in,
-            "log_scale_x": log_scale_x,
-            "log_scale_y": log_scale_y,
-            "show_grid": show_grid,
-            "color_cycle": color_cycle,
-        }
-        tries = 0
-        while tries < 2:
-            try:
-                for attribute, value in params_values.items():
-                    setattr(
-                        self,
-                        attribute,
-                        value
-                        if value != "default"
-                        else self.default_params["Figure"][attribute],
-                    )
-                break  # Exit loop if successful
-            except KeyError as e:
-                tries += 1
-                if tries >= 2:
-                    raise GraphingException(
-                        f"There was an error auto updating your {self.figure_style} style file following the recent GraphingLib update. Please notify the developers by creating an issue on GraphingLib's GitHub page. In the meantime, you can manually add the following parameter to your {self.figure_style} style file:\n Figure.{e.args[0]}"
-                    )
-                file_updater = FileUpdater(self.figure_style)
-                file_updater.update()
-                file_loader = FileLoader(self.figure_style)
-                self.default_params = file_loader.load()
 
     def add_element(self, *elements: Plottable) -> None:
         """
@@ -213,6 +166,11 @@ class Figure:
         """
         Prepares the :class:`~graphinglib.figure.Figure` to be displayed.
         """
+        self._fill_in_missing_params(self)
+        self.color_cycle = cycler(color=self.color_cycle)
+        if self.show_grid:
+            self.set_grid()
+
         self._figure, self._axes = plt.subplots(figsize=self.size)
         try:
             self._axes.grid(

--- a/graphinglib/multifigure.py
+++ b/graphinglib/multifigure.py
@@ -496,6 +496,10 @@ class MultiFigure:
             Wheter or not to display the legend inside a box.
             Default depends on the ``figure_style`` configuration.
         """
+        if type(num_rows) != int or type(num_cols) != int:
+            raise TypeError("The number of rows and columns must be integers.")
+        if num_rows < 1 or num_cols < 1:
+            raise ValueError("The number of rows and columns must be greater than 0.")
         self.num_rows = num_rows
         self.num_cols = num_cols
         self.title = title
@@ -577,12 +581,19 @@ class MultiFigure:
         new_SubFigure : :class:`~graphinglib.multifigure.SubFigure`
             :class:`~graphinglib.multifigure.SubFigure` to be added to the :class:`~graphinglib.multifigure.MultiFigure`.
         """
-        if row_start >= self.num_rows or col_start >= self.num_cols:
-            raise GraphingException(
-                "The placement values must be inside the size of the MultiFigure."
-            )
+
+        if type(row_start) != int or type(col_start) != int:
+            raise TypeError("The placement values must be integers.")
         if row_start < 0 or col_start < 0:
-            raise GraphingException("The placement values cannot be negative.")
+            raise ValueError("The placement values cannot be negative.")
+        if type(row_span) != int or type(col_span) != int:
+            raise TypeError("The span values must be integers.")
+        if row_span < 1 or col_span < 1:
+            raise ValueError("The span values must be greater than 0.")
+        if row_start + row_span > self.num_rows or col_start + col_span > self.num_cols:
+            raise ValueError(
+                "The placement values and span values must be inside the size of the MultiFigure."
+            )
         new_SubFigure = SubFigure(
             row_start,
             col_start,

--- a/graphinglib/multifigure.py
+++ b/graphinglib/multifigure.py
@@ -155,7 +155,6 @@ class SubFigure:
         self.log_scale_y = log_scale_y
         self.show_grid = show_grid
         self.color_cycle = color_cycle
-        self.color_cycle = cycler(color=self.color_cycle)
         self.add_reference_label = add_reference_label
         self.remove_axes = remove_axes
         self.grid_is_set = False
@@ -192,6 +191,7 @@ class SubFigure:
         Prepares the :class:`~graphinglib.multifigure.SubFigure` to be displayed.
         """
         self._fill_in_missing_params(self)
+        self.color_cycle = cycler(color=self.color_cycle)
         self._axes = plt.subplot(
             grid.new_subplotspec(
                 (self.row_start, self.col_start),
@@ -576,7 +576,7 @@ class MultiFigure:
         new_SubFigure : :class:`~graphinglib.multifigure.SubFigure`
             :class:`~graphinglib.multifigure.SubFigure` to be added to the :class:`~graphinglib.multifigure.MultiFigure`.
         """
-        if row_start >= self.size[0] or col_start >= self.size[1]:
+        if row_start >= self.num_rows or col_start >= self.num_cols:
             raise GraphingException(
                 "The placement values must be inside the size of the MultiFigure."
             )

--- a/unit_testing/figure_test.py
+++ b/unit_testing/figure_test.py
@@ -1,6 +1,5 @@
 import unittest
 
-from matplotlib.pyplot import Axes
 from numpy import linspace, pi, sin
 
 from graphinglib.data_plotting_1d import Curve

--- a/unit_testing/figure_test.py
+++ b/unit_testing/figure_test.py
@@ -63,6 +63,8 @@ class TestFigure(unittest.TestCase):
 
     def test_assign_figure_params_horrible(self):
         a_figure = Figure(figure_style="horrible")
+        a_figure.add_element(self.testCurve)
+        a_figure._prepare_figure()
         self.assertListEqual(list(a_figure.size), [10, 7])
 
     def test_assign_figure_params_not_boxed(self):

--- a/unit_testing/figure_test.py
+++ b/unit_testing/figure_test.py
@@ -70,3 +70,11 @@ class TestFigure(unittest.TestCase):
     def test_assign_figure_params_not_boxed(self):
         a_figure = Figure(figure_style="horrible", legend_is_boxed=False)
         self.assertFalse(a_figure.legend_is_boxed)
+
+    def test_element_defaults_are_reset(self):
+        self.testCurve.line_width = "default"
+        self.testFigure.add_element(self.testCurve)
+        self.testFigure._prepare_figure()
+        self.assertEqual(self.testCurve.line_width, "default")
+        self.testFigure._fill_in_missing_params(self.testCurve)
+        self.assertEqual(self.testCurve.line_width, 2)

--- a/unit_testing/figure_test.py
+++ b/unit_testing/figure_test.py
@@ -4,6 +4,7 @@ from numpy import linspace, pi, sin
 
 from graphinglib.data_plotting_1d import Curve
 from graphinglib.figure import Figure
+from graphinglib.file_manager import FileLoader
 from graphinglib.graph_elements import GraphingException
 
 
@@ -12,6 +13,8 @@ class TestFigure(unittest.TestCase):
         x = linspace(0, 3 * pi, 200)
         self.testFigure = Figure()
         self.testCurve = Curve(x, sin(x), "Test Curve", color="k")
+        self.plainDefaults = FileLoader("plain").load()
+        self.horribleDefaults = FileLoader("horrible").load()
 
     def test_curves_is_list(self):
         self.assertIsInstance(self.testFigure._elements, list)
@@ -41,6 +44,7 @@ class TestFigure(unittest.TestCase):
         a_curve = Curve(x, sin(x), label="Test Curve")
         a_figure = Figure()
         a_figure.add_element(a_curve)
+        a_figure.default_params = self.plainDefaults
         a_figure._fill_in_missing_params(a_curve)
         self.assertEqual(a_curve.line_width, 2)
 
@@ -49,6 +53,7 @@ class TestFigure(unittest.TestCase):
         a_curve = Curve(x, sin(x), label="Test Curve")
         a_figure = Figure(figure_style="horrible")
         a_figure.add_element(a_curve)
+        a_figure.default_params = self.horribleDefaults
         a_figure._fill_in_missing_params(a_curve)
         self.assertEqual(a_curve.line_width, 10)
 
@@ -57,13 +62,15 @@ class TestFigure(unittest.TestCase):
         a_curve = Curve(x, sin(x), label="Test Curve", line_width=3)
         a_figure = Figure()
         a_figure.add_element(a_curve)
+        a_figure.default_params = self.plainDefaults
         a_figure._fill_in_missing_params(a_curve)
         self.assertEqual(a_curve.line_width, 3)
 
     def test_assign_figure_params_horrible(self):
         a_figure = Figure(figure_style="horrible")
         a_figure.add_element(self.testCurve)
-        a_figure._prepare_figure()
+        a_figure.default_params = self.horribleDefaults
+        a_figure._fill_in_missing_params(a_figure)
         self.assertListEqual(list(a_figure.size), [10, 7])
 
     def test_assign_figure_params_not_boxed(self):
@@ -77,3 +84,24 @@ class TestFigure(unittest.TestCase):
         self.assertEqual(self.testCurve.line_width, "default")
         self.testFigure._fill_in_missing_params(self.testCurve)
         self.assertEqual(self.testCurve.line_width, 2)
+
+    def test_handles_and_labels_cleared(self):
+        self.testFigure.add_element(self.testCurve)
+        self.testFigure._prepare_figure()
+        self.assertEqual(len(self.testFigure._handles), 0)
+        self.assertEqual(len(self.testFigure._labels), 0)
+
+    def test_handles_and_labels_added(self):
+        self.testFigure.add_element(self.testCurve)
+        other_curve = Curve(self.testCurve.x_data, self.testCurve.y_data, "Other Curve")
+        self.testFigure.add_element(other_curve)
+        self.testFigure._prepare_figure()
+        handles, labels = self.testFigure._axes.get_legend_handles_labels()
+        self.assertEqual(len(handles), 2)
+        self.assertListEqual(labels, ["Test Curve", "Other Curve"])
+        # test if still ok when replotting
+        self.testFigure.figure_style = "horrible"
+        self.testFigure._prepare_figure()
+        handles, labels = self.testFigure._axes.get_legend_handles_labels()
+        self.assertEqual(len(handles), 2)
+        self.assertListEqual(labels, ["Test Curve", "Other Curve"])

--- a/unit_testing/multifigure_test.py
+++ b/unit_testing/multifigure_test.py
@@ -1,0 +1,190 @@
+import unittest
+
+from graphinglib.data_plotting_1d import Curve
+from graphinglib.file_manager import FileLoader
+from graphinglib.multifigure import MultiFigure, SubFigure
+
+
+class TestMultiFigure(unittest.TestCase):
+    def setUp(self):
+        self.test_curve = Curve.from_function(lambda x: x**2, 0, 10, "Test Curve")
+        self.small_multifigure = MultiFigure(1, 1)
+        self.big_multifigure = MultiFigure(4, 4)
+
+    def test_create_multifigure(self):
+        a_multifig = MultiFigure(num_rows=2, num_cols=2)
+        self.assertEqual(a_multifig.num_rows, 2)
+        self.assertEqual(a_multifig.num_cols, 2)
+
+        # Test that raises error if num_rows or num_cols is not an integer or is less than 1
+        with self.assertRaises(TypeError):
+            MultiFigure(num_rows=2.5, num_cols=2)
+        with self.assertRaises(ValueError):
+            MultiFigure(num_rows=0, num_cols=2)
+        with self.assertRaises(ValueError):
+            MultiFigure(num_rows=2, num_cols=0)
+
+    def test_create_subfigure(self):
+        self.small_multifigure.add_SubFigure(
+            row_start=0, col_start=0, row_span=1, col_span=1
+        )
+
+    def test_create_subfigure_wrong_span(self):
+        # Test that raises error if row_start or col_start is not an integer or is less than 0
+        with self.assertRaises(TypeError):
+            self.small_multifigure.add_SubFigure(
+                row_start=0.5, col_start=0, row_span=1, col_span=1
+            )
+        with self.assertRaises(ValueError):
+            self.small_multifigure.add_SubFigure(
+                row_start=-1, col_start=0, row_span=1, col_span=1
+            )
+        with self.assertRaises(TypeError):
+            self.small_multifigure.add_SubFigure(
+                row_start=0, col_start=0.5, row_span=1, col_span=1
+            )
+
+    def test_create_subfigure_span_too_high(self):
+        # Test that raises error if row_span or col_span is greater than or equal to num_rows or num_cols
+        with self.assertRaises(ValueError):
+            self.small_multifigure.add_SubFigure(
+                row_start=0, col_start=0, row_span=2, col_span=1
+            )
+        with self.assertRaises(ValueError):
+            self.small_multifigure.add_SubFigure(
+                row_start=0, col_start=0, row_span=1, col_span=2
+            )
+
+    def test_create_subfigure_start_too_high(self):
+        # Test that raises error if row_start or col_start is greater than or equal to num_rows or num_cols
+        with self.assertRaises(ValueError):
+            self.small_multifigure.add_SubFigure(
+                row_start=1, col_start=0, row_span=1, col_span=1
+            )
+        with self.assertRaises(ValueError):
+            self.small_multifigure.add_SubFigure(
+                row_start=0, col_start=1, row_span=1, col_span=1
+            )
+
+    def test_fill_in_missing_params_plain(self):
+        # Fill in values for plain style
+        self.small_multifigure.add_SubFigure(
+            row_start=0, col_start=0, row_span=1, col_span=1
+        )
+        self.small_multifigure.default_params = FileLoader("plain").load()
+        self.small_multifigure._fill_in_missing_params(self.small_multifigure)
+        self.assertEqual(self.small_multifigure.legend_is_boxed, False)
+
+    def test_fill_in_missing_params_horrible(self):
+        # Fill in values for horrible style
+        self.small_multifigure.add_SubFigure(
+            row_start=0, col_start=0, row_span=1, col_span=1
+        )
+        self.small_multifigure.default_params = FileLoader("horrible").load()
+        self.small_multifigure._fill_in_missing_params(self.small_multifigure)
+        self.assertEqual(self.small_multifigure.legend_is_boxed, True)
+
+    def test_reset_params_to_default(self):
+        self.small_multifigure.add_SubFigure(
+            row_start=0, col_start=0, row_span=1, col_span=1
+        )
+        self.small_multifigure.default_params = FileLoader("plain").load()
+        params = self.small_multifigure._fill_in_missing_params(self.small_multifigure)
+        self.small_multifigure._reset_params_to_default(self.small_multifigure, params)
+        self.assertEqual(self.small_multifigure.legend_is_boxed, "default")
+
+
+class TestSubFigure(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_curve = Curve.from_function(lambda x: x**2, 0, 10, "Test Curve")
+        self.other_curve = Curve.from_function(lambda x: x**3, 0, 10, "Other Curve")
+        self.subfigure = SubFigure(0, 0, 1, 1)
+
+    def test_add_element(self):
+        self.subfigure.add_element(self.test_curve)
+        self.assertEqual(self.subfigure._elements[0], self.test_curve)
+
+        # Add multiple elements
+        self.subfigure.add_element(self.other_curve, self.test_curve)
+        self.assertListEqual(
+            self.subfigure._elements,
+            [self.test_curve, self.other_curve, self.test_curve],
+        )
+
+    def test_fill_in_missing_params_plain(self):
+        self.subfigure.default_params = FileLoader("plain").load()
+        self.subfigure._fill_in_missing_params(self.subfigure)
+        self.assertEqual(self.subfigure.legend_is_boxed, False)
+
+    def test_fill_in_missing_params_curve(self):
+        self.subfigure.add_element(self.test_curve)
+        self.subfigure.default_params = FileLoader("plain").load()
+        self.subfigure._fill_in_missing_params(self.test_curve)
+        self.assertEqual(self.test_curve.line_style, "-")
+        self.assertEqual(self.test_curve.line_width, 2)
+
+    def test_fill_in_missing_params_horrible(self):
+        self.subfigure.default_params = FileLoader("horrible").load()
+        self.subfigure._fill_in_missing_params(self.subfigure)
+        self.assertEqual(self.subfigure.legend_is_boxed, True)
+
+    def test_dont_overwrite_specified_params(self):
+        self.subfigure.legend_is_boxed = False
+        self.subfigure.default_params = FileLoader("horrible").load()
+        self.subfigure._fill_in_missing_params(self.subfigure)
+        self.assertEqual(self.subfigure.legend_is_boxed, False)
+
+    def test_dont_overwrite_specified_params_curve(self):
+        self.test_curve.line_style = "--"
+        self.test_curve.line_width = 3
+        self.subfigure.add_element(self.test_curve)
+        self.subfigure.default_params = FileLoader("plain").load()
+        self.subfigure._fill_in_missing_params(self.test_curve)
+        self.assertEqual(self.test_curve.line_style, "--")
+        self.assertEqual(self.test_curve.line_width, 3)
+
+    def test_reset_params_to_default(self):
+        self.subfigure.default_params = FileLoader("plain").load()
+        params = self.subfigure._fill_in_missing_params(self.subfigure)
+        self.subfigure._reset_params_to_default(self.subfigure, params)
+        self.assertEqual(self.subfigure.legend_is_boxed, "default")
+
+    def test_raise_exception_if_no_element_added(self):
+        multifig = MultiFigure(1, 1)
+        multifig.add_SubFigure(0, 0, 1, 1)
+        with self.assertRaises(Exception):
+            multifig._prepare_MultiFigure()
+
+    def test_all_curves_plotted(self):
+        multifig = MultiFigure(1, 1)
+        sub1 = multifig.add_SubFigure(0, 0, 1, 1)
+        sub1.add_element(self.test_curve)
+        multifig._prepare_MultiFigure()
+        self.assertEqual(len(sub1._axes.get_lines()), len(sub1._elements))
+
+    def test_handles_and_labels_cleared(self):
+        multifig = MultiFigure(1, 1)
+        sub1 = multifig.add_SubFigure(row_start=0, col_start=0, row_span=1, col_span=1)
+        sub1.add_element(self.test_curve)
+        multifig._prepare_MultiFigure()
+        self.assertEqual(len(sub1._handles), 0)
+        self.assertEqual(len(sub1._labels), 0)
+
+    def test_handles_and_labels_added(self):
+        multifig = MultiFigure(1, 1)
+        sub1 = multifig.add_SubFigure(row_start=0, col_start=0, row_span=1, col_span=1)
+        sub1.add_element(self.test_curve)
+        other_curve = Curve(
+            self.test_curve.x_data, self.test_curve.y_data, "Other Curve"
+        )
+        sub1.add_element(other_curve)
+        multifig._prepare_MultiFigure()
+        handles, labels = sub1._axes.get_legend_handles_labels()
+        self.assertEqual(len(handles), 2)
+        self.assertListEqual(labels, ["Test Curve", "Other Curve"])
+        # test if still ok when replotting
+        multifig.figure_style = "horrible"
+        multifig._prepare_MultiFigure()
+        handles, labels = sub1._axes.get_legend_handles_labels()
+        self.assertEqual(len(handles), 2)
+        self.assertListEqual(labels, ["Test Curve", "Other Curve"])


### PR DESCRIPTION
## PR summary

Closes issue #272.

Lots of moving around and reorganization of the default fetching logic for Figure and MultiFigure. Doesn't change anything on the user side, but makes the code easier to read and more logical. Also fixed a few related bugs which hadn't been spotted yet. Added lots of unit tests to make sure the refactoring didn't break anything. There probably will be a few bugs to iron out from this, but I think I dealt with all the most common and obvious ones plus many non obvious ones. But the unit tests are much more solid than they were for Figure, MultiFigure, and SubFigure.

## PR checklist

- [x] Links to the related issue (#....)
- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete and documentation modified
- [x] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [x] If new files have been added, make sure they aren't excluded by .gitignore
- [x] Any new data files have been added to manifest.in
