### PR TITLE
Reset rc_params after displaying

### DIFF
--- a/graphinglib/figure.py
+++ b/graphinglib/figure.py
@@ -95,6 +95,7 @@ class Figure:
         self.x_lim = x_lim
         self.y_lim = y_lim
         self._rc_dict = {}
+        self._user_rc_dict = {}
 
     def add_element(self, *elements: Plottable) -> None:
         """
@@ -180,6 +181,8 @@ class Figure:
         self._reset_params_to_default(self, figure_params_to_reset)
         self._handles = []
         self._labels = []
+        self._rc_dict = {}
+        plt.rcParams.update(plt.rcParamsDefault)
 
     def display(self, legend: bool = True) -> None:
         """
@@ -281,7 +284,7 @@ class Figure:
             Dictionary of rc parameters to update.
             Defaults depends on the ``figure_style`` configuration.
         """
-        self._rc_dict = rc_params_dict
+        self._user_rc_dict = rc_params_dict
 
     def _fill_in_rc_params(self):
         """
@@ -292,4 +295,5 @@ class Figure:
             # add to rc_dict if not already in there
             if property not in self._rc_dict:
                 self._rc_dict[property] = value
-        plt.rcParams.update(self._rc_dict)
+        all_rc_params = {**self._rc_dict, **self._user_rc_dict}
+        plt.rcParams.update(all_rc_params)

--- a/graphinglib/multifigure.py
+++ b/graphinglib/multifigure.py
@@ -402,6 +402,7 @@ class MultiFigure:
         self.size = size
         self._SubFigures = []
         self._rc_dict = {}
+        self._user_rc_dict = {}
 
     def add_SubFigure(
         self,
@@ -555,6 +556,8 @@ class MultiFigure:
                 )
         self._figure.suptitle(self.title)
         self._reset_params_to_default(self, multi_figure_params_to_reset)
+        self._rc_dict = {}
+        plt.rcParams.update(rcParamsDefault)
 
     def display(
         self,
@@ -669,7 +672,7 @@ class MultiFigure:
             Dictionary of rc parameters to update.
             Defaults depends on the ``figure_style`` configuration.
         """
-        self._rc_dict = rc_params_dict
+        self._user_rc_dict = rc_params_dict
 
     def _fill_in_rc_params(self):
         """
@@ -680,4 +683,5 @@ class MultiFigure:
             # add to rc_dict if not already in there
             if property not in self._rc_dict:
                 self._rc_dict[property] = value
-        plt.rcParams.update(self._rc_dict)
+        all_rc_params = {**self._rc_dict, **self._user_rc_dict}
+        plt.rcParams.update(all_rc_params)


### PR DESCRIPTION
## PR summary
Fixes issue #281. Split the _rc_dict in two, one for figure style params (which is emptied at the end of plotting) and one for user specified rc_params which are specified in the code with the customize_visual_style function (which is assumed to specify desired properties for all plots regardless of style) which isn't reset after plotting. 

When updating the params with plt.blablabla, both dictionaries are passed. After plotting, matplotlib's default rc_params are put back. 

## PR checklist

- [x] Links to the related issue (#....)
- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete and documentation modified
- [x] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [x] If new files have been added, make sure they aren't excluded by .gitignore
- [x] Any new data files have been added to manifest.in
