### PR TITLE
280 feature request possibility to use matplotlib default styles

### DIFF
--- a/graphinglib/data_plotting_1d.py
+++ b/graphinglib/data_plotting_1d.py
@@ -65,7 +65,7 @@ class Curve:
     color: str = "default"
     line_width: float | Literal["default"] = "default"
     line_style: str = "default"
-    errorbars: bool = field(default=False, init=False)
+    show_errorbars: bool = field(default=False, init=False)
     _fill_curve_between: Optional[tuple[float, float]] = field(init=False, default=None)
 
     @classmethod
@@ -237,7 +237,7 @@ class Curve:
             Thickness of the errorbar caps.
             Default depends on the ``figure_style`` configuration.
         """
-        self.errorbars = True
+        self.show_errorbars = True
         self.x_error = np.array(x_error) if x_error is not None else x_error
         self.y_error = np.array(y_error) if y_error is not None else y_error
         self.errorbars_color = errorbars_color
@@ -691,36 +691,45 @@ class Curve:
         """
         Plots the element in the specified axes.
         """
-        if self.errorbars:
+        if self.show_errorbars:
+            params = {
+                "color": self.color,
+                "linewidth": self.line_width,
+                "linestyle": self.line_style,
+                "elinewidth": self.errorbars_line_width,
+                "capsize": self.cap_width,
+                "capthick": self.cap_thickness,
+                "ecolor": self.errorbars_color,
+            }
+            params = {k: v for k, v in params.items() if v != "default"}
             self.handle = axes.errorbar(
                 self.x_data,
                 self.y_data,
                 xerr=self.x_error,
                 yerr=self.y_error,
-                color=self.color,
-                linewidth=self.line_width,
-                linestyle=self.line_style,
                 label=self.label,
-                elinewidth=self.errorbars_line_width,
-                capsize=self.cap_width,
-                capthick=self.cap_thickness,
-                ecolor=self.errorbars_color,
                 zorder=z_order,
+                **params,
             )
         else:
+            params = {
+                "color": self.color,
+                "linewidth": self.line_width,
+                "linestyle": self.line_style,
+            }
+            params = {k: v for k, v in params.items() if v != "default"}
             self.handle = axes.errorbar(
                 self.x_data,
                 self.y_data,
-                color=self.color,
-                linewidth=self.line_width,
-                linestyle=self.line_style,
                 label=self.label,
                 zorder=z_order,
+                **params,
             )
         if self._fill_curve_between:
-            kwargs = {}
+            kwargs = {"alpha": 0.2}
             if self.fill_under_color:
                 kwargs["color"] = self.fill_under_color
+            kwargs = {k: v for k, v in kwargs.items() if v != "default"}
             axes.fill_between(
                 self.x_data,
                 self.y_data,
@@ -728,7 +737,6 @@ class Curve:
                     self.x_data >= self._fill_curve_between[0],
                     self.x_data <= self._fill_curve_between[1],
                 ),
-                alpha=0.2,
                 zorder=z_order - 2,
                 **kwargs,
             )
@@ -1089,34 +1097,46 @@ class Scatter:
         Plots the element in the specified axes.
         """
         if self.errorbars:
+            params = {
+                "markerfacecolor": self.face_color,
+                "markeredgecolor": self.edge_color,
+                "markersize": self.marker_size,
+                "marker": self.marker_style,
+                "elinewidth": self.errorbars_line_width,
+                "capsize": self.cap_width,
+                "capthick": self.cap_thickness,
+                "ecolor": self.errorbars_color,
+                "linestyle": "none",
+            }
+            if params["marker"] == "default":
+                params["marker"] = "o"
+            params = {k: v for k, v in params.items() if v != "default"}
             self.handle = axes.errorbar(
                 self.x_data,
                 self.y_data,
                 xerr=self.x_error,
                 yerr=self.y_error,
-                markerfacecolor=self.face_color,
-                markeredgecolor=self.edge_color,
-                markersize=self.marker_size,
-                marker=self.marker_style,
                 label=self.label,
-                elinewidth=self.errorbars_line_width,
-                capsize=self.cap_width,
-                capthick=self.cap_thickness,
-                ecolor=self.errorbars_color,
-                linestyle="none",
                 zorder=z_order,
+                **params,
             )
         else:
+            params = {
+                "markerfacecolor": self.face_color,
+                "markeredgecolor": self.edge_color,
+                "markersize": self.marker_size,
+                "marker": self.marker_style,
+                "linestyle": "none",
+            }
+            if params["marker"] == "default":
+                params["marker"] = "o"
+            params = {k: v for k, v in params.items() if v != "default"}
             self.handle = axes.errorbar(
                 self.x_data,
                 self.y_data,
-                markerfacecolor=self.face_color,
-                markeredgecolor=self.edge_color,
-                markersize=self.marker_size,
-                marker=self.marker_style,
                 label=self.label,
-                linestyle="none",
                 zorder=z_order,
+                **params,
             )
 
 
@@ -1310,22 +1330,38 @@ class Histogram:
         """
         Plots the element in the specified axes.
         """
+        params = {
+            "facecolor": to_rgba(self.face_color, self.alpha)
+            if self.face_color != "default" and self.alpha != "default"
+            else "default",
+            "edgecolor": to_rgba(self.edge_color, 1)
+            if self.edge_color != "default"
+            else self.edge_color,
+            "linewidth": self.line_width,
+        }
+        params = {k: v for k, v in params.items() if v != "default"}
         self.handle = Polygon(
             np.array([[0, 2, 2, 3, 3, 1, 1, 0, 0], [0, 0, 1, 1, 2, 2, 3, 3, 0]]).T,
-            facecolor=to_rgba(self.face_color, self.alpha),
-            edgecolor=to_rgba(self.edge_color, 1),
-            linewidth=1,
+            **params,
         )
+        params = {
+            "facecolor": to_rgba(self.face_color, self.alpha)
+            if self.face_color != "default" and self.alpha != "default"
+            else "default",
+            "edgecolor": to_rgba(self.edge_color, 1)
+            if self.edge_color != "default"
+            else self.edge_color,
+            "histtype": self.hist_type,
+            "linewidth": self.line_width,
+            "density": self.normalize,
+        }
+        params = {k: v for k, v in params.items() if v != "default"}
         axes.hist(
             self.data,
             bins=self.number_of_bins,
-            facecolor=to_rgba(self.face_color, self.alpha),
-            edgecolor=to_rgba(self.edge_color, 1),
             label=self.label,
-            histtype=self.hist_type,
-            linewidth=self.line_width,
-            density=self.normalize,
             zorder=z_order - 1,
+            **params,
         )
         if self.show_pdf in ["normal", "gaussian"]:
             normal = (

--- a/graphinglib/data_plotting_2d.py
+++ b/graphinglib/data_plotting_2d.py
@@ -146,25 +146,33 @@ class Heatmap:
         `Axes <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.html>`_.
         """
         if self.x_axis_range is not None and self.y_axis_range is not None:
+            params = {
+                "cmap": self.color_map,
+                "alpha": self.alpha_value,
+                "aspect": self.aspect_ratio,
+                "origin": self.origin_position,
+                "interpolation": self.interpolation,
+                "extent": self._xy_range,
+            }
+            params = {k: v for k, v in params.items() if v != "default"}
             image = axes.imshow(
                 self.image,
-                cmap=self.color_map,
-                alpha=self.alpha_value,
-                aspect=self.aspect_ratio,
-                origin=self.origin_position,
-                interpolation=self.interpolation,
-                extent=self._xy_range,
                 zorder=z_order,
+                **params,
             )
         else:
+            params = {
+                "cmap": self.color_map,
+                "alpha": self.alpha_value,
+                "aspect": self.aspect_ratio,
+                "origin": self.origin_position,
+                "interpolation": self.interpolation,
+            }
+            params = {k: v for k, v in params.items() if v != "default"}
             image = axes.imshow(
                 self.image,
-                cmap=self.color_map,
-                alpha=self.alpha_value,
-                aspect=self.aspect_ratio,
-                origin=self.origin_position,
-                interpolation=self.interpolation,
                 zorder=z_order,
+                **params,
             )
         fig = axes.get_figure()
         if self.show_color_bar:
@@ -182,9 +190,6 @@ class VectorField:
         x and y coordinates of the vectors.
     u_data, v_data : ArrayLike
         Magnitudes in the x and y coordinates.
-    arrow_length_multiplier : float, optional
-        Arrow length scaling factor.
-        Default depends on the ``figure_style`` configuration.
     arrow_width : float
         Arrow width.
         Default depends on the ``figure_style`` configuration.
@@ -210,7 +215,6 @@ class VectorField:
     y_data: ArrayLike
     u_data: ArrayLike
     v_data: ArrayLike
-    arrow_length_multiplier: Optional[float | Literal["default"]] = "default"
     arrow_width: float | Literal["default"] = "default"
     arrow_head_width: float | Literal["default"] = "default"
     arrow_head_length: float | Literal["default"] = "default"
@@ -227,12 +231,11 @@ class VectorField:
     @classmethod
     def from_function(
         cls,
-        func: Callable[[ArrayLike, ArrayLike], [ArrayLike, ArrayLike]],
+        func: Callable[[ArrayLike, ArrayLike], tuple[ArrayLike, ArrayLike]],
         x_axis_range: tuple[float, float],
         y_axis_range: tuple[float, float],
         number_of_arrows_x: int = 10,
         number_of_arrows_y: int = 10,
-        arrow_length_multiplier: Optional[float | Literal["default"]] = "default",
         arrow_width: float | Literal["default"] = "default",
         arrow_head_width: float | Literal["default"] = "default",
         arrow_head_length: float | Literal["default"] = "default",
@@ -245,7 +248,7 @@ class VectorField:
 
         Parameters
         ----------
-        func : Callable[[ArrayLike, ArrayLike], [ArrayLike, ArrayLike]]
+        func : Callable[[ArrayLike, ArrayLike], tuple[ArrayLike, ArrayLike]]
             Function to be plotted. Works with regular functions and lambda
             functions.
         x_data, y_data : ArrayLike
@@ -254,9 +257,6 @@ class VectorField:
             Magnitudes in the x and y coordinates.
         number_of_arrows_x, number_of_arrows_y : int
             Number of arrows to plot in the x and y direction. Defaults to 10.
-        arrow_length_multiplier : float, optional
-            Arrow length scaling factor.
-            Default depends on the ``figure_style`` configuration.
         arrow_width : float
             Arrow width.
             Default depends on the ``figure_style`` configuration.
@@ -290,7 +290,6 @@ class VectorField:
             y_grid,
             u,
             v,
-            arrow_length_multiplier,
             arrow_width,
             arrow_head_width,
             arrow_head_length,
@@ -308,19 +307,23 @@ class VectorField:
             angle = "xy"
         else:
             angle = "uv"
+        params = {
+            "angles": angle,
+            "width": self.arrow_width,
+            "headwidth": self.arrow_head_width,
+            "headlength": self.arrow_head_length,
+            "headaxislength": self.arrow_head_axis_length,
+            "color": self.color,
+        }
+        params = {k: v for k, v in params.items() if v != "default"}
         axes.quiver(
             self.x_data,
             self.y_data,
             self.u_data,
             self.v_data,
-            color=self.color,
-            zorder=z_order,
-            angles=angle,
             # scale=self.arrow_length_multiplier,
-            width=self.arrow_width,
-            headwidth=self.arrow_head_width,
-            headlength=self.arrow_head_length,
-            headaxislength=self.arrow_head_axis_length,
+            zorder=z_order,
+            **params,
         )
 
 
@@ -433,25 +436,27 @@ class Contour:
         Plots the element in the specified
         `Axes <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.html>`_.
         """
+        params = {
+            "levels": self.number_of_levels,
+            "cmap": self.color_map,
+            "alpha": self.alpha,
+        }
+        params = {k: v for k, v in params.items() if v != "default"}
         if self.filled:
             cont = axes.contourf(
                 self.x_mesh,
                 self.y_mesh,
                 self.z_data,
-                levels=self.number_of_levels,
-                cmap=self.color_map,
-                alpha=self.alpha,
                 zorder=z_order,
+                **params,
             )
         else:
             cont = axes.contour(
                 self.x_mesh,
                 self.y_mesh,
                 self.z_data,
-                levels=self.number_of_levels,
-                cmap=self.color_map,
-                alpha=self.alpha,
                 zorder=z_order,
+                **params,
             )
         if self.show_color_bar:
             fig = axes.get_figure()
@@ -501,7 +506,7 @@ class Stream:
     @classmethod
     def from_function(
         cls,
-        func: Callable[[ArrayLike, ArrayLike], [ArrayLike, ArrayLike]],
+        func: Callable[[ArrayLike, ArrayLike], tuple[ArrayLike, ArrayLike]],
         x_axis_range: tuple[float, float],
         y_axis_range: tuple[float, float],
         number_of_points_x: int = 30,
@@ -554,15 +559,19 @@ class Stream:
         """
         Plots the element in the specified Axes.
         """
+        params = {
+            "density": self.density,
+            "linewidth": self.line_width,
+            "color": self.color,
+            "cmap": self.color_map,
+            "arrowsize": self.arrow_size,
+        }
+        params = {k: v for k, v in params.items() if v != "default"}
         axes.streamplot(
             self.x_data,
             self.y_data,
             self.u_data,
             self.v_data,
-            density=self.density,
-            linewidth=self.line_width,
-            color=self.color,
-            cmap=self.color_map,
-            arrowsize=self.arrow_size,
             zorder=z_order,
+            **params,
         )

--- a/graphinglib/default_styles/horrible.yml
+++ b/graphinglib/default_styles/horrible.yml
@@ -43,8 +43,6 @@ Figure:
   size: [10, 7]
   log_scale_x: False
   log_scale_y: False
-  show_grid: True
-  color_cycle: ["#a1d0ff", "#730127", "#789146", "#8800ff", "#00b3a7", "#dbc00f", "#8a8a8a", "#28301c"]
 
 MultiFigure:
   size: [10, 7]
@@ -52,8 +50,6 @@ MultiFigure:
 SubFigure:
   log_scale_x: False
   log_scale_y: False
-  show_grid: True
-  color_cycle: ["#a1d0ff", "#730127", "#789146", "#8800ff", "#00b3a7", "#dbc00f", "#8a8a8a", "#28301c"]
 
 Point:
   color: "cyan"
@@ -132,7 +128,6 @@ Contour:
 
 VectorField:
   arrow_width: 0.015
-  arrow_length_multiplier: None
   arrow_head_width: 3
   arrow_head_length: 5
   arrow_head_axis_length: 6
@@ -161,6 +156,7 @@ rc_params:
   axes.edgecolor: "black"
   axes.labelcolor: "black"
   axes.linewidth: 1
+  axes.prop_cycle: cycler('color', ['#a1d0ff', '#730127', '#789146', '#8800ff', '#00b3a7', '#dbc00f', '#8a8a8a', '#28301c'])
   xtick.color: "black"
   ytick.color: "black"
   xtick.direction: "in"

--- a/graphinglib/default_styles/plain.yml
+++ b/graphinglib/default_styles/plain.yml
@@ -43,8 +43,6 @@ Figure:
   size: [6.4, 4.8]
   log_scale_x: False
   log_scale_y: False
-  show_grid: False
-  color_cycle: ["#3e82a0", "#edb73b", "#b9503b", "#8aba4e", "#695178", "#ed893b", "#34a893", "#616161"]
 
 MultiFigure:
   size: [6.4, 4.8]
@@ -52,8 +50,6 @@ MultiFigure:
 SubFigure:
   log_scale_x: False
   log_scale_y: False
-  show_grid: False
-  color_cycle: ["#3e82a0", "#edb73b", "#b9503b", "#8aba4e", "#695178", "#ed893b", "#34a893", "#616161"]
 
 Point:
   color: "k"
@@ -132,7 +128,6 @@ Contour:
 
 VectorField:
   arrow_width: 0.005
-  arrow_length_multiplier: 
   arrow_head_width: 3
   arrow_head_length: 5
   arrow_head_axis_length: 4.5
@@ -161,6 +156,7 @@ rc_params:
   axes.edgecolor: "black"
   axes.labelcolor: "black"
   axes.linewidth: 1
+  axes.prop_cycle: cycler('color', ['#3e82a0', '#edb73b', '#b9503b', '#8aba4e', '#695178', '#ed893b', '#34a893', '#616161'])
   xtick.color: "black"
   ytick.color: "black"
   xtick.direction: "in"
@@ -177,3 +173,5 @@ rc_params:
   grid.linewidth: 0.5
   grid.color: "grey"
   grid.alpha: 0.5
+  axes.grid: False
+  

--- a/graphinglib/figure.py
+++ b/graphinglib/figure.py
@@ -113,11 +113,23 @@ class Figure:
         """
         Prepares the :class:`~graphinglib.figure.Figure` to be displayed.
         """
-        file_loader = FileLoader(self.figure_style)
-        self.default_params = file_loader.load()
+        try:
+            file_loader = FileLoader(self.figure_style)
+            self.default_params = file_loader.load()
+            self._fill_in_rc_params()
+        except FileNotFoundError:
+            # set the style use matplotlib style
+            try:
+                plt.style.use(self.figure_style)
+                file_loader = FileLoader("plain")
+                self.default_params = file_loader.load()
+            except OSError:
+                raise GraphingException(
+                    f"The figure style {self.figure_style} was not found. Please choose a different style."
+                )
+
         figure_params_to_reset = self._fill_in_missing_params(self)
 
-        self._fill_in_rc_params()
         self._figure, self._axes = plt.subplots(figsize=self.size)
 
         if self.show_grid:
@@ -138,7 +150,7 @@ class Figure:
         if self.log_scale_y:
             self._axes.set_yscale("log")
         if self._elements:
-            z_order = 0
+            z_order = 1
             for element in self._elements:
                 params_to_reset = self._fill_in_missing_params(element)
                 element._plot_element(self._axes, z_order)

--- a/graphinglib/figure.py
+++ b/graphinglib/figure.py
@@ -1,7 +1,6 @@
 from typing import Literal, Optional
 
 import matplotlib.pyplot as plt
-from cycler import cycler
 from matplotlib.collections import LineCollection
 from matplotlib.legend_handler import HandlerPatch
 from matplotlib.patches import Polygon
@@ -38,9 +37,6 @@ class Figure:
         Default depends on the ``figure_style`` configuration.
     figure_style : str
         The figure style to use for the figure.
-    color_cycle : list[str]
-        List of colors applied to the elements cyclically if none is provided.
-        Default depends on the ``figure_style`` configuration.
     """
 
     def __init__(
@@ -54,7 +50,6 @@ class Figure:
         log_scale_y: bool | Literal["default"] = "default",
         show_grid: bool | Literal["default"] = "default",
         figure_style: str = "plain",
-        color_cycle: list[str] | Literal["default"] = "default",
     ) -> None:
         """
         This class implements a general figure object.
@@ -77,16 +72,15 @@ class Figure:
             Default depends on the ``figure_style`` configuration.
         figure_style : str
             The figure style to use for the figure.
-        color_cycle : list[str]
-            List of colors applied to the elements cyclically if none is provided.
-            Default depends on the ``figure_style`` configuration.
         """
         self.figure_style = figure_style
         self.size = size
         self.log_scale_x = log_scale_x
         self.log_scale_y = log_scale_y
-        self.show_grid = show_grid
-        self.color_cycle = color_cycle
+        if show_grid == "default":
+            self.show_grid = "unchanged"
+        else:
+            self.show_grid = show_grid
         self._elements: list[Plottable] = []
         self._labels: list[str | None] = []
         self._handles = []
@@ -113,6 +107,7 @@ class Figure:
         """
         Prepares the :class:`~graphinglib.figure.Figure` to be displayed.
         """
+        is_matplotlib_style = self.figure_style in plt.style.available
         try:
             file_loader = FileLoader(self.figure_style)
             self.default_params = file_loader.load()
@@ -132,13 +127,13 @@ class Figure:
 
         self._figure, self._axes = plt.subplots(figsize=self.size)
 
-        if self.show_grid:
+        if self.show_grid == "unchanged":
+            pass
+        elif self.show_grid:
             self._axes.grid(True)
         else:
             self._axes.grid(False)
 
-        self.color_cycle = cycler(color=self.color_cycle)
-        self._axes.set_prop_cycle(self.color_cycle)
         self._axes.set_xlabel(self.x_axis_name)
         self._axes.set_ylabel(self.y_axis_name)
         if self.x_lim:
@@ -152,9 +147,12 @@ class Figure:
         if self._elements:
             z_order = 1
             for element in self._elements:
-                params_to_reset = self._fill_in_missing_params(element)
+                params_to_reset = []
+                if not is_matplotlib_style:
+                    params_to_reset = self._fill_in_missing_params(element)
                 element._plot_element(self._axes, z_order)
-                self._reset_params_to_default(element, params_to_reset)
+                if not is_matplotlib_style:
+                    self._reset_params_to_default(element, params_to_reset)
                 try:
                     if element.label is not None:
                         self._handles.append(element.handle)

--- a/graphinglib/file_manager.py
+++ b/graphinglib/file_manager.py
@@ -129,7 +129,9 @@ def get_colors(figure_style: str = "plain") -> list[str]:
     """
     file_loader = FileLoader(figure_style)
     style_info = file_loader.load()
-    colors = style_info["Figure"]["color_cycle"]
+    colors = style_info["rc_params"]["axes.prop_cycle"]
+    colors = colors[colors.find("[") + 1 : colors.find("]")].split(", ")
+    colors = [color[1:-1] for color in colors]
     return colors
 
 

--- a/graphinglib/fits.py
+++ b/graphinglib/fits.py
@@ -202,39 +202,49 @@ class GeneralFit(Curve):
         Plots the element in the specified
         Axes
         """
+        params = {
+            "color": self.color,
+            "linewidth": self.line_width,
+            "linestyle": self.line_style,
+        }
+        params = {key: value for key, value in params.items() if value != "default"}
         (self.handle,) = axes.plot(
             self.x_data,
             self.y_data,
             label=self.label,
-            color=self.color,
-            linewidth=self.line_width,
-            linestyle=self.line_style,
             zorder=z_order,
+            **params,
         )
         if self._res_curves_to_be_plotted:
-            x_data = self.x_data
             y_fit = self.y_data
             residuals = self.calculate_residuals()
             std = np.std(residuals)
             y_fit_plus_std = y_fit + (self.res_sigma_multiplier * std)
             y_fit_minus_std = y_fit - (self.res_sigma_multiplier * std)
+            params = {
+                "color": self.res_color,
+                "linewidth": self.res_line_width,
+                "linestyle": self.res_line_style,
+            }
+            params = {key: value for key, value in params.items() if value != "default"}
             axes.plot(
                 self.x_data,
                 y_fit_minus_std,
-                color=self.res_color,
-                linewidth=self.res_line_width,
-                linestyle=self.res_line_style,
                 zorder=z_order,
+                **params,
             )
             axes.plot(
                 self.x_data,
                 y_fit_plus_std,
-                color=self.res_color,
-                linewidth=self.res_line_width,
-                linestyle=self.res_line_style,
                 zorder=z_order,
+                **params,
             )
         if self._fill_curve_between:
+            params = {
+                "alpha": 0.2,
+                "color": self.fill_color,
+            }
+            params = {key: value for key, value in params.items() if value != "default"}
             axes.fill_between(
                 self.x_data,
                 self.y_data,
@@ -242,9 +252,8 @@ class GeneralFit(Curve):
                     self.x_data >= self._fill_curve_between[0],
                     self.x_data <= self._fill_curve_between[1],
                 ),
-                # color=self.fill_color,
-                alpha=0.2,
                 zorder=z_order - 2,
+                **params,
             )
 
     def show_residual_curves(

--- a/graphinglib/graph_elements.py
+++ b/graphinglib/graph_elements.py
@@ -151,29 +151,37 @@ class Hlines:
         Axes
         """
         if isinstance(self.y, list) and len(self.y) > 1:
+            params = {
+                "colors": self.colors,
+                "linestyles": self.line_styles,
+                "linewidths": self.line_widths,
+            }
+            params = {k: v for k, v in params.items() if v != "default"}
             axes.hlines(
                 self.y,
                 self.x_min,
                 self.x_max,
-                colors=self.colors,
-                linestyles=self.line_styles,
-                linewidths=self.line_widths,
                 zorder=z_order,
+                **params,
             )
+            params.pop("linewidths")
             self.handle = LineCollection(
                 [[(0, 0)]] * (len(self.y) if len(self.y) <= 3 else 3),
-                color=self.colors,
-                linestyle="solid",
+                **params,
             )
         else:
+            params = {
+                "colors": self.colors,
+                "linestyles": self.line_styles,
+                "linewidths": self.line_widths,
+            }
+            params = {k: v for k, v in params.items() if v != "default"}
             self.handle = axes.hlines(
                 self.y,
                 self.x_min,
                 self.x_max,
-                colors=self.colors,
-                linestyles=self.line_styles,
-                linewidths=self.line_widths,
                 zorder=z_order,
+                **params,
             )
 
 
@@ -293,29 +301,37 @@ class Vlines:
         Axes
         """
         if isinstance(self.x, list) and len(self.x) > 1:
+            params = {
+                "colors": self.colors,
+                "linestyles": self.line_styles,
+                "linewidths": self.line_widths,
+            }
+            params = {k: v for k, v in params.items() if v != "default"}
             axes.vlines(
                 self.x,
                 self.y_min,
                 self.y_max,
-                colors=self.colors,
-                linestyles=self.line_styles,
-                linewidths=self.line_widths,
                 zorder=z_order,
+                **params,
             )
+            params.pop("linewidths")
             self.handle = VerticalLineCollection(
                 [[(0, 0)]] * (len(self.x) if len(self.x) <= 4 else 4),
-                color=self.colors,
-                linestyle="solid",
+                **params,
             )
         else:
+            params = {
+                "colors": self.colors,
+                "linestyles": self.line_styles,
+                "linewidths": self.line_widths,
+            }
+            params = {k: v for k, v in params.items() if v != "default"}
             self.handle = axes.vlines(
                 self.x,
                 self.y_min,
                 self.y_max,
-                colors=self.colors,
-                linestyles=self.line_styles,
-                linewidths=self.line_widths,
                 zorder=z_order,
+                **params,
             )
 
 
@@ -450,24 +466,32 @@ class Point:
             point_label = prefix + self.label + postfix
         else:
             point_label = None
+        params = {
+            "c": self.color,
+            "edgecolors": self.edge_color,
+            "s": self.marker_size,
+            "marker": self.marker_style,
+            "linewidths": self.edge_width,
+        }
+        params = {k: v for k, v in params.items() if v != "default"}
         axes.scatter(
             self.x,
             self.y,
-            c=self.color,
-            edgecolors=self.edge_color,
-            s=self.marker_size,
-            marker=self.marker_style,
-            linewidths=self.edge_width,
             zorder=z_order,
+            **params,
         )
+        params = {
+            "color": self.text_color,
+            "fontsize": size,
+            "horizontalalignment": self.h_align,
+            "verticalalignment": self.v_align,
+        }
+        params = {k: v for k, v in params.items() if v != "default"}
         axes.annotate(
             point_label,
             (self.x, self.y),
-            color=self.text_color,
-            fontsize=size,
-            horizontalalignment=self.h_align,
-            verticalalignment=self.v_align,
             zorder=z_order,
+            **params,
         )
         if self._show_coordinates:
             prefix = " " if self.h_align == "left" else ""
@@ -482,14 +506,18 @@ class Point:
                 )
             else:
                 point_label = prefix + f"({self.x:.3f}, {self.y:.3f})" + postfix
+            params = {
+                "color": self.text_color,
+                "fontsize": size,
+                "horizontalalignment": self.h_align,
+                "verticalalignment": self.v_align,
+            }
+            params = {k: v for k, v in params.items() if v != "default"}
             axes.annotate(
                 point_label,
                 (self.x, self.y),
-                color=self.text_color,
-                fontsize=size,
-                horizontalalignment=self.h_align,
-                verticalalignment=self.v_align,
                 zorder=z_order,
+                **params,
             )
 
 
@@ -573,28 +601,38 @@ class Text:
         Axes
         """
         size = self.font_size if self.font_size != "same as figure" else None
+        params = {
+            "color": self.color,
+            "fontsize": size,
+            "horizontalalignment": self.h_align,
+            "verticalalignment": self.v_align,
+        }
+        params = {k: v for k, v in params.items() if v != "default"}
         axes.text(
             self.x,
             self.y,
             self.text,
-            horizontalalignment=self.h_align,
-            verticalalignment=self.v_align,
-            color=self.color,
-            fontsize=size,
             zorder=z_order,
+            **params,
         )
         if self._arrow_pointing_to is not None:
             self.arrow_properties["color"] = self.color
+            params = {
+                "color": self.color,
+                "fontsize": size,
+                "horizontalalignment": self.h_align,
+                "verticalalignment": self.v_align,
+            }
+            params = {k: v for k, v in params.items() if v != "default"}
+            if self.color != "default":
+                self.arrow_properties["color"] = self.color
+                params["arrowprops"] = self.arrow_properties
             axes.annotate(
                 self.text,
                 self._arrow_pointing_to,
                 xytext=(self.x, self.y),
-                color=self.color,
-                arrowprops=self.arrow_properties,
-                fontsize=size,
-                horizontalalignment=self.h_align,
-                verticalalignment=self.v_align,
                 zorder=z_order,
+                **params,
             )
 
 
@@ -663,19 +701,23 @@ class Table:
         """
         Plots the element in the specified Axes
         """
+        params = {
+            "cellLoc": self.cell_align,
+            "colLoc": self.col_align,
+            "rowLoc": self.row_align,
+        }
+        params = {k: v for k, v in params.items() if v != "default"}
         table = axes.table(
             cellText=self.cell_text,
             cellColours=self.cell_colors,
-            cellLoc=self.cell_align,
             colLabels=self.col_labels,
             colWidths=self.col_widths,
-            colLoc=self.col_align,
             colColours=self.col_colors,
             rowLabels=self.row_labels,
-            rowLoc=self.row_align,
             rowColours=self.row_colors,
             loc=self.location,
             zorder=z_order,
+            **params,
         )
         table.auto_set_font_size(False)
         table.scale(self.scaling[0], self.scaling[1])

--- a/graphinglib/multifigure.py
+++ b/graphinglib/multifigure.py
@@ -166,8 +166,18 @@ class SubFigure:
         """
         Prepares the :class:`~graphinglib.multifigure.SubFigure` to be displayed.
         """
-        file_loader = FileLoader(self.figure_style)
-        self.default_params = file_loader.load()
+        try:
+            file_loader = FileLoader(self.figure_style)
+            self.default_params = file_loader.load()
+        except FileNotFoundError:
+            try:
+                plt.style.use(self.figure_style)
+                file_loader = FileLoader("plain")
+                self.default_params = file_loader.load()
+            except OSError:
+                raise GraphingException(
+                    f"The figure style {self.figure_style} was not found. Please choose a different style."
+                )
         figure_params_to_reset = self._fill_in_missing_params(self)
         self._axes = plt.subplot(
             grid.new_subplotspec(
@@ -207,7 +217,7 @@ class SubFigure:
                 )
             )
         if self._elements:
-            z_order = 0
+            z_order = 1
             for element in self._elements:
                 params_to_reset = self._fill_in_missing_params(element)
                 element._plot_element(self._axes, z_order)
@@ -498,11 +508,22 @@ class MultiFigure:
         """
         Prepares the :class:`~graphinglib.multifigure.MultiFigure` to be displayed.
         """
-        file_loader = FileLoader(self.figure_style)
-        self.default_params = file_loader.load()
+        try:
+            file_loader = FileLoader(self.figure_style)
+            self.default_params = file_loader.load()
+            self._fill_in_rc_params()
+        except FileNotFoundError:
+            try:
+                plt.style.use(self.figure_style)
+                file_loader = FileLoader("plain")
+                self.default_params = file_loader.load()
+            except OSError:
+                raise GraphingException(
+                    f"The figure style {self.figure_style} was not found. Please choose a different style."
+                )
+
         multi_figure_params_to_reset = self._fill_in_missing_params(self)
 
-        self._fill_in_rc_params()
         self._figure = plt.figure(layout="constrained", figsize=self.size)
         MultiFigure_grid = GridSpec(self.num_rows, self.num_cols, figure=self._figure)
 

--- a/graphinglib/multifigure.py
+++ b/graphinglib/multifigure.py
@@ -3,7 +3,6 @@ from typing import Literal, Optional
 from warnings import warn
 
 import matplotlib.pyplot as plt
-from cycler import cycler
 from matplotlib import rcParamsDefault
 from matplotlib.axes import Axes
 from matplotlib.collections import LineCollection
@@ -49,9 +48,6 @@ class SubFigure:
         The limits for the x-axis and y-axis.
     figure_style : str
         The figure style to use for the figure.
-    color_cycle : list[str]
-        List of colors applied to the elements cyclically if none is provided.
-        Default depends on the ``figure_style`` configuration.
     add_reference_label : bool
         Whether or not to add a reference label to the SubFigure.
         Defaults to ``True``.
@@ -77,7 +73,6 @@ class SubFigure:
         x_lim: Optional[tuple[float, float]] = None,
         y_lim: Optional[tuple[float, float]] = None,
         figure_style: str = "plain",
-        color_cycle: list[str] | Literal["default"] = "default",
         add_reference_label: bool = True,
         log_scale_x: bool | Literal["default"] = "default",
         log_scale_y: bool | Literal["default"] = "default",
@@ -110,9 +105,6 @@ class SubFigure:
             The limits for the x-axis and y-axis.
         figure_style : str
             The figure style to use for the figure.
-        color_cycle : list[str]
-            List of colors applied to the elements cyclically if none is provided.
-            Default depends on the ``figure_style`` configuration.
         add_reference_label : bool
             Whether or not to add a reference label to the SubFigure.
             Defaults to ``True``.
@@ -135,8 +127,10 @@ class SubFigure:
         self.figure_style = figure_style
         self.log_scale_x = log_scale_x
         self.log_scale_y = log_scale_y
-        self.show_grid = show_grid
-        self.color_cycle = color_cycle
+        if show_grid == "default":
+            self.show_grid = "unchanged"
+        else:
+            self.show_grid = show_grid
         self.add_reference_label = add_reference_label
         self.remove_axes = remove_axes
         self._elements: list[Plottable] = []
@@ -166,6 +160,7 @@ class SubFigure:
         """
         Prepares the :class:`~graphinglib.multifigure.SubFigure` to be displayed.
         """
+        is_matplotlib_style = self.figure_style in plt.style.available
         try:
             file_loader = FileLoader(self.figure_style)
             self.default_params = file_loader.load()
@@ -179,6 +174,7 @@ class SubFigure:
                     f"The figure style {self.figure_style} was not found. Please choose a different style."
                 )
         figure_params_to_reset = self._fill_in_missing_params(self)
+
         self._axes = plt.subplot(
             grid.new_subplotspec(
                 (self.row_start, self.col_start),
@@ -193,12 +189,12 @@ class SubFigure:
                 reference_label,
                 transform=self._axes.transAxes + transformation,
             )
-        if self.show_grid:
+        if self.show_grid == "unchanged":
+            pass
+        elif self.show_grid:
             self._axes.grid(True)
         else:
             self._axes.grid(False)
-        self.color_cycle = cycler(color=self.color_cycle)
-        self._axes.set_prop_cycle(self.color_cycle)
         self._axes.set_xlabel(self.x_axis_name)
         self._axes.set_ylabel(self.y_axis_name)
         if self.x_lim:
@@ -217,11 +213,13 @@ class SubFigure:
                 )
             )
         if self._elements:
-            z_order = 1
+            z_order = 12
             for element in self._elements:
-                params_to_reset = self._fill_in_missing_params(element)
+                if not is_matplotlib_style:
+                    params_to_reset = self._fill_in_missing_params(element)
                 element._plot_element(self._axes, z_order)
-                self._reset_params_to_default(element, params_to_reset)
+                if not is_matplotlib_style:
+                    self._reset_params_to_default(element, params_to_reset)
                 try:
                     if element.label is not None:
                         self._handles.append(element.handle)
@@ -426,7 +424,6 @@ class MultiFigure:
         y_lim: Optional[tuple[float, float]] = None,
         log_scale_x: bool | Literal["default"] = "default",
         log_scale_y: bool | Literal["default"] = "default",
-        color_cycle: list[str] | Literal["default"] = "default",
         show_grid: bool | Literal["default"] = "default",
         remove_axes: bool = False,
     ) -> SubFigure:
@@ -450,9 +447,6 @@ class MultiFigure:
             The limits for the x-axis and y-axis.
         log_scale_x, log_scale_y : bool
             Whether or not to set the scale of the x- or y-axis to logaritmic scale.
-            Default depends on the ``figure_style`` configuration.
-        color_cycle : list[str]
-            List of colors applied to the elements cyclically if none is provided.
             Default depends on the ``figure_style`` configuration.
         show_grid : bool
             Wheter or not to show the grid.
@@ -489,7 +483,6 @@ class MultiFigure:
             x_lim,
             y_lim,
             self.figure_style,
-            color_cycle,
             self.reference_labels,
             log_scale_x,
             log_scale_y,

--- a/unit_testing/file_manager_test.py
+++ b/unit_testing/file_manager_test.py
@@ -53,7 +53,9 @@ class TestGetColors(unittest.TestCase):
         mock_file_loader_instance = MagicMock()
         mock_file_loader.return_value = mock_file_loader_instance
         mock_file_loader_instance.load.return_value = {
-            "Figure": {"color_cycle": ["red", "green", "blue"]}
+            "rc_params": {
+                "axes.prop_cycle": "cycler('cycler', ['red', 'green', 'blue'])"
+            }
         }
         colors = get_colors("plain")
         self.assertEqual(colors, ["red", "green", "blue"])
@@ -67,7 +69,9 @@ class TestGetColor(unittest.TestCase):
         mock_file_loader_instance = MagicMock()
         mock_file_loader.return_value = mock_file_loader_instance
         mock_file_loader_instance.load.return_value = {
-            "Figure": {"color_cycle": ["red", "green", "blue"]}
+            "rc_params": {
+                "axes.prop_cycle": "cycler('color', ['red', 'green', 'blue'])"
+            }
         }
         color = get_color("plain", 1)
         self.assertEqual(color, "green")

--- a/unit_testing/multifigure_test.py
+++ b/unit_testing/multifigure_test.py
@@ -114,7 +114,7 @@ class TestSubFigure(unittest.TestCase):
     def test_fill_in_missing_params_plain(self):
         self.subfigure.default_params = FileLoader("plain").load()
         self.subfigure._fill_in_missing_params(self.subfigure)
-        self.assertEqual(self.subfigure.show_grid, False)
+        self.assertEqual(self.subfigure.log_scale_x, False)
 
     def test_fill_in_missing_params_curve(self):
         self.subfigure.add_element(self.test_curve)
@@ -126,7 +126,7 @@ class TestSubFigure(unittest.TestCase):
     def test_fill_in_missing_params_horrible(self):
         self.subfigure.default_params = FileLoader("horrible").load()
         self.subfigure._fill_in_missing_params(self.subfigure)
-        self.assertEqual(self.subfigure.show_grid, True)
+        self.assertEqual(self.subfigure.log_scale_x, False)
 
     def test_dont_overwrite_specified_params(self):
         self.subfigure.show_grid = False
@@ -147,7 +147,7 @@ class TestSubFigure(unittest.TestCase):
         self.subfigure.default_params = FileLoader("plain").load()
         params = self.subfigure._fill_in_missing_params(self.subfigure)
         self.subfigure._reset_params_to_default(self.subfigure, params)
-        self.assertEqual(self.subfigure.show_grid, "default")
+        self.assertEqual(self.subfigure.log_scale_x, "default")
 
     def test_raise_exception_if_no_element_added(self):
         multifig = MultiFigure(1, 1)


### PR DESCRIPTION
## PR summary

Many changes in order to make use of matplotlib styles possible. Many visual parameters (which don't affect function, only style) were moved to be handled by rc_params. I intend to bring some of them back through methods which I don't expect to be used very often.

## PR checklist

- [x] Links to the related issue (#....)
- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete and documentation modified
- [x] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [x] If new files have been added, make sure they aren't excluded by .gitignore
- [x] Any new data files have been added to manifest.in
