### PR TITLE
Added support for matplotlib default style : "matplotlib"

### DIFF
--- a/graphinglib/figure.py
+++ b/graphinglib/figure.py
@@ -107,15 +107,20 @@ class Figure:
         """
         Prepares the :class:`~graphinglib.figure.Figure` to be displayed.
         """
-        is_matplotlib_style = self.figure_style in plt.style.available
         try:
             file_loader = FileLoader(self.figure_style)
             self.default_params = file_loader.load()
             self._fill_in_rc_params()
+            is_matplotlib_style = False
         except FileNotFoundError:
             # set the style use matplotlib style
             try:
-                plt.style.use(self.figure_style)
+                is_matplotlib_style = True
+                if self.figure_style == "matplotlib":
+                    # set the style to default
+                    plt.style.use("default")
+                else:
+                    plt.style.use(self.figure_style)
                 file_loader = FileLoader("plain")
                 self.default_params = file_loader.load()
             except OSError:

--- a/graphinglib/file_manager.py
+++ b/graphinglib/file_manager.py
@@ -130,6 +130,8 @@ def get_colors(figure_style: str = "plain") -> list[str]:
     list[str]
         A list of colors.
     """
+    if figure_style == "matplotlib":
+        figure_style = "default"
     try:
         file_loader = FileLoader(figure_style)
         style_info = file_loader.load()
@@ -137,7 +139,7 @@ def get_colors(figure_style: str = "plain") -> list[str]:
         colors = colors[colors.find("[") + 1 : colors.find("]")].split(", ")
         colors = [color[1:-1] for color in colors]
     except FileNotFoundError:
-        if figure_style in plt.style.available:
+        if figure_style in plt.style.available or figure_style == "default":
             with plt.style.context(figure_style):
                 colors = plt.rcParams["axes.prop_cycle"].by_key()["color"]
         else:

--- a/graphinglib/multifigure.py
+++ b/graphinglib/multifigure.py
@@ -13,12 +13,9 @@ from matplotlib.transforms import ScaledTranslation
 
 from .file_manager import FileLoader, FileUpdater
 from .graph_elements import GraphingException, Plottable, Text
-from .legend_artists import (
-    HandlerMultipleLines,
-    HandlerMultipleVerticalLines,
-    VerticalLineCollection,
-    histogram_legend_artist,
-)
+from .legend_artists import (HandlerMultipleLines,
+                             HandlerMultipleVerticalLines,
+                             VerticalLineCollection, histogram_legend_artist)
 
 
 class SubFigure:
@@ -160,15 +157,19 @@ class SubFigure:
         """
         Prepares the :class:`~graphinglib.multifigure.SubFigure` to be displayed.
         """
-        is_matplotlib_style = self.figure_style in plt.style.available
         try:
             file_loader = FileLoader(self.figure_style)
             self.default_params = file_loader.load()
+            is_matplotlib_style = False
         except FileNotFoundError:
             try:
-                plt.style.use(self.figure_style)
+                if self.figure_style == "matplotlib":
+                    plt.style.use("default")
+                else:
+                    plt.style.use(self.figure_style)
                 file_loader = FileLoader("plain")
                 self.default_params = file_loader.load()
+                is_matplotlib_style = True
             except OSError:
                 raise GraphingException(
                     f"The figure style {self.figure_style} was not found. Please choose a different style."
@@ -507,7 +508,10 @@ class MultiFigure:
             self._fill_in_rc_params()
         except FileNotFoundError:
             try:
-                plt.style.use(self.figure_style)
+                if self.figure_style == "matplotlib":
+                    plt.style.use("default")
+                else:
+                    plt.style.use(self.figure_style)
                 file_loader = FileLoader("plain")
                 self.default_params = file_loader.load()
             except OSError:


### PR DESCRIPTION
## PR summary
 Closes issue #290. The matplotlib default style is set by setting figure_style = "matplotlib".

## PR checklist

- [x] Links to the related issue (#....)
- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete and documentation modified
- [x] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [x] If new files have been added, make sure they aren't excluded by .gitignore
- [x] Any new data files have been added to manifest.in
