### PR TITLE
312 feature request : new figure/subfigure/multifigure organization

### DIFF
--- a/graphinglib/__init__.py
+++ b/graphinglib/__init__.py
@@ -34,5 +34,5 @@ from .fits import (
     FitFromSquareRoot,
 )
 from .graph_elements import GraphingException, Hlines, Point, Table, Text, Vlines
-from .multifigure import MultiFigure, SubFigure
+from .multifigure import MultiFigure
 from .shapes import Circle, Rectangle

--- a/graphinglib/figure.py
+++ b/graphinglib/figure.py
@@ -234,7 +234,7 @@ class Figure:
         Parameters
         ----------
         legend : bool
-            Wheter or not to display the legend. The legend is always set to be
+            Whether or not to display the legend. The legend is always set to be
             draggable.
             Defaults to ``True``.
         """
@@ -249,6 +249,8 @@ class Figure:
 
         Parameters
         ----------
+        file_name : str
+            The name of the file to save the figure to.
         legend : bool
             Wheter or not to display the legend.
             Defaults to ``True``.

--- a/graphinglib/multifigure.py
+++ b/graphinglib/multifigure.py
@@ -11,12 +11,10 @@ from matplotlib.transforms import ScaledTranslation
 
 from graphinglib.file_manager import FileLoader
 from graphinglib.graph_elements import GraphingException, Plottable
-from graphinglib.legend_artists import (
-    HandlerMultipleLines,
-    HandlerMultipleVerticalLines,
-    VerticalLineCollection,
-    histogram_legend_artist,
-)
+from graphinglib.legend_artists import (HandlerMultipleLines,
+                                        HandlerMultipleVerticalLines,
+                                        VerticalLineCollection,
+                                        histogram_legend_artist)
 
 from .figure import Figure
 
@@ -439,7 +437,10 @@ class MultiFigure:
         Fills in the missing rc parameters from the specified ``figure_style``.
         """
         if is_matplotlib_style:
-            plt.style.use(self.figure_style)
+            if self.figure_style == "matplotlib":
+                plt.style.use("default")
+            else:
+                plt.style.use(self.figure_style)
             plt.rcParams.update(self._user_rc_dict)
         else:
             params = self.default_params["rc_params"]

--- a/graphinglib/multifigure.py
+++ b/graphinglib/multifigure.py
@@ -120,6 +120,52 @@ class MultiFigure:
         self._rc_dict = {}
         self._user_rc_dict = {}
 
+    @classmethod
+    def row(
+        cls,
+        figures: list[Figure],
+        size: tuple[float, float] | Literal["default"] = "default",
+        title: Optional[str] = None,
+        reference_labels: bool = True,
+        reflabel_loc: str = "outside",
+        figure_style: str = "plain",
+    ):
+        multi_fig = cls(
+            num_rows=1,
+            num_cols=len(figures),
+            size=size,
+            title=title,
+            reference_labels=reference_labels,
+            reflabel_loc=reflabel_loc,
+            figure_style=figure_style,
+        )
+        for i, figure in enumerate(figures):
+            multi_fig.add_sub_figure(figure, 0, i, 1, 1)
+        return multi_fig
+
+    @classmethod
+    def stack(
+        cls,
+        figures: list[Figure],
+        size: tuple[float, float] | Literal["default"] = "default",
+        title: Optional[str] = None,
+        reference_labels: bool = True,
+        reflabel_loc: str = "outside",
+        figure_style: str = "plain",
+    ):
+        multi_fig = cls(
+            num_rows=len(figures),
+            num_cols=1,
+            size=size,
+            title=title,
+            reference_labels=reference_labels,
+            reflabel_loc=reflabel_loc,
+            figure_style=figure_style,
+        )
+        for i, figure in enumerate(figures):
+            multi_fig.add_sub_figure(figure, i, 0, 1, 1)
+        return multi_fig
+
     def add_sub_figure(
         self,
         sub_figure: Figure,

--- a/graphinglib/multifigure.py
+++ b/graphinglib/multifigure.py
@@ -11,10 +11,12 @@ from matplotlib.transforms import ScaledTranslation
 
 from graphinglib.file_manager import FileLoader
 from graphinglib.graph_elements import GraphingException, Plottable
-from graphinglib.legend_artists import (HandlerMultipleLines,
-                                        HandlerMultipleVerticalLines,
-                                        VerticalLineCollection,
-                                        histogram_legend_artist)
+from graphinglib.legend_artists import (
+    HandlerMultipleLines,
+    HandlerMultipleVerticalLines,
+    VerticalLineCollection,
+    histogram_legend_artist,
+)
 
 from .figure import Figure
 
@@ -70,8 +72,8 @@ class MultiFigure:
         """
         This class implements the "canvas" on which multiple plots are displayed.
 
-        The canvas consists of a grid of a specified size on which the
-        :class:`~graphinglib.multifigure.SubFigure` objects are displayed.
+        The canvas consists of a grid of a specified size on which the individual
+        :class:`~graphinglib.figure.Figure` objects are displayed.
 
         Parameters
         ----------
@@ -127,7 +129,33 @@ class MultiFigure:
         reference_labels: bool = True,
         reflabel_loc: str = "outside",
         figure_style: str = "plain",
-    ):
+    ) -> None:
+        """Creates a MultiFigure with the specified :class:`~graphinglib.figure.Figure` objects in a horizontal configuration.
+
+        Parameters
+        ----------
+        figures : list[Figure]
+            The :class:`~graphinglib.figure.Figure` objects to add to the MultiFigure, from left to right.
+        size : tuple[float, float]
+            Overall size of the figure.
+            Default depends on the ``figure_style`` configuration.
+        title : str, optional
+            Title of the MultiFigure.
+            Defaults to ``None``.
+        reference_labels : bool
+            Whether or not to add reference labels to the SubFigures.
+            Defaults to ``True``.
+        reflabel_loc : str
+            Location of the reference labels of the SubFigures. Either "inside" or "outside".
+            Defaults to "outside".
+        figure_style : str
+            The figure style to use for the figure.
+            Defaults to "plain".
+
+        Returns
+        -------
+        A new MultiFigure object.
+        """
         multi_fig = cls(
             num_rows=1,
             num_cols=len(figures),
@@ -150,7 +178,33 @@ class MultiFigure:
         reference_labels: bool = True,
         reflabel_loc: str = "outside",
         figure_style: str = "plain",
-    ):
+    ) -> None:
+        """Creates a MultiFigure with the specified :class:`~graphinglib.figure.Figure` objects in a vertical configuration.
+
+        Parameters
+        ----------
+        figures : list[Figure]
+            The :class:`~graphinglib.figure.Figure` objects to add to the MultiFigure, from top to bottom.
+        size : tuple[float, float]
+            Overall size of the figure.
+            Default depends on the ``figure_style`` configuration.
+        title : str, optional
+            Title of the MultiFigure.
+            Defaults to ``None``.
+        reference_labels : bool
+            Whether or not to add reference labels to the SubFigures.
+            Defaults to ``True``.
+        reflabel_loc : str
+            Location of the reference labels of the SubFigures. Either "inside" or "outside".
+            Defaults to "outside".
+        figure_style : str
+            The figure style to use for the figure.
+            Defaults to "plain".
+
+        Returns
+        -------
+        A new MultiFigure object.
+        """
         multi_fig = cls(
             num_rows=len(figures),
             num_cols=1,
@@ -171,9 +225,9 @@ class MultiFigure:
         col_start: int,
         row_span: int,
         col_span: int,
-    ):
+    ) -> None:
         """
-        Adds a :class:`~graphinglib.multifigure.SubFigure` to a :class:`~graphinglib.multifigure.MultiFigure`.
+        Adds a :class:`~graphinglib.figure.Figure` to a :class:`~graphinglib.multifigure.MultiFigure`.
 
         Parameters
         ----------
@@ -220,14 +274,14 @@ class MultiFigure:
         Parameters
         ----------
         general_legend : bool
-            Wheter or not to display a overall legend for the :class:`~graphinglib.multifigure.MultiFigure` containing
-            the labels for every :class:`~graphinglib.multifigure.SubFigure` in it. Note that enabling this option will
+            Whether or not to display an overall legend for the :class:`~graphinglib.multifigure.MultiFigure` containing
+            the labels of every :class:`~graphinglib.Figure.Figure` inside it. Note that enabling this option will
             disable the individual legends for every :class:`~graphinglib.multifigure.SubFigure`.
             Defaults to ``False``.
         legend_loc : str
             The location of the legend in the MultiFigure. Possible placement keywords are: for vertical placement: ``{"upper", "center", "lower"}``, for horizontal placement: ``{"left", "center", "right"}``. The keyword ``"outside"`` can be added to put the legend outside of the axes. Defaults to ``"outside lower center"``.
         legend_cols : int
-            Number of colums in which to arange the legend items. Defaults to 1.
+            Number of colums in which to arrange the legend items. Defaults to 1.
         """
         self._prepare_multi_figure(
             general_legend=general_legend,
@@ -245,21 +299,21 @@ class MultiFigure:
         legend_cols: int = 1,
     ) -> None:
         """
-        Saves the :class:`~graphinglib.multifigure.MultiFigure`.
+        Saves the :class:`~graphinglib.multifigure.MultiFigure` to a file.
 
         Parameters
         ----------
         file_name : str
             File name or path at which to save the figure.
         general_legend : bool
-            Wheter or not to display a overall legend for the :class:`~graphinglib.multifigure.MultiFigure` containing
-            the labels for every :class:`~graphinglib.multifigure.SubFigure` in it. Note that enabling this option will
-            disable the individual legends for every :class:`~graphinglib.multifigure.SubFigure`.
+            Whether or not to display an overall legend for the :class:`~graphinglib.multifigure.MultiFigure` containing
+            the labels of every :class:`~graphinglib.figure.Figure` inside it. Note that enabling this option will
+            disable the individual legends for every :class:`~graphinglib.figure.Figure`.
             Defaults to ``False``.
         legend_loc : str
             The location of the legend in the MultiFigure. Possible placement keywords are: for vertical placement: ``{"upper", "center", "lower"}``, for horizontal placement: ``{"left", "center", "right"}``. The keyword ``"outside"`` can be added to put the legend outside of the axes. Defaults to ``"outside lower center"``.
         legend_cols : int
-            Number of colums in which to arange the legend items. Defaults to 1.
+            Number of colums in which to arrange the legend items. Defaults to 1.
         """
         self._prepare_multi_figure(
             general_legend=general_legend,
@@ -369,7 +423,9 @@ class MultiFigure:
         legend: bool,
         is_matplotlib_style: bool,
     ):
-        # Set rc for subfigure
+        """
+        Prepares a single subfigure.
+        """
         sub_rcs = sub_figure._user_rc_dict
         plt.rcParams.update(sub_rcs)
         axes = plt.subplot(
@@ -434,7 +490,10 @@ class MultiFigure:
 
     def _fill_in_rc_params(self, is_matplotlib_style: bool = False) -> None:
         """
-        Fills in the missing rc parameters from the specified ``figure_style``.
+        Fills in and sets the missing rc parameters from the specified ``figure_style``.
+        If ``is_matplotlib_style`` is ``True``, the rc parameters are reset to the default values for the specified ``figure_style``.
+        If ``is_matplotlib_style`` is ``False``, the rc parameters are updated with the missing parameters from the specified ``figure_style``.
+        In both cases, the rc parameters are then updated with the user-specified parameters.
         """
         if is_matplotlib_style:
             if self.figure_style == "matplotlib":
@@ -459,7 +518,7 @@ class MultiFigure:
         reset: bool = False,
     ) -> None:
         """
-        Customize the visual style of the :class:`~graphinglib.figure.Figure`.
+        Customize the visual style of the :class:`~graphinglib.multifigure.MultiFigure`.
 
         Any rc parameter that is not specified in the dictionary will be set to the default value for the specified ``figure_style``.
 

--- a/graphinglib/multifigure.py
+++ b/graphinglib/multifigure.py
@@ -1,374 +1,24 @@
 from string import ascii_lowercase
 from typing import Literal, Optional
-from warnings import warn
 
 import matplotlib.pyplot as plt
 from matplotlib import rcParamsDefault
-from matplotlib.axes import Axes
 from matplotlib.collections import LineCollection
 from matplotlib.gridspec import GridSpec
 from matplotlib.legend_handler import HandlerPatch
 from matplotlib.patches import Polygon
 from matplotlib.transforms import ScaledTranslation
 
-from .file_manager import FileLoader, FileUpdater
-from .graph_elements import GraphingException, Plottable, Text
-from .legend_artists import (
+from graphinglib.file_manager import FileLoader
+from graphinglib.graph_elements import GraphingException, Plottable
+from graphinglib.legend_artists import (
     HandlerMultipleLines,
     HandlerMultipleVerticalLines,
     VerticalLineCollection,
     histogram_legend_artist,
 )
 
-
-class SubFigure:
-    """
-    This class implements the individual plots added inside the
-    :class:`~graphinglib.multifigure.MultiFigure` object.
-
-    .. attention::
-
-        This class is not meant to be used directly by the user. Instead, it is used in
-        conjunction with the :class:`~graphinglib.multifigure.MultiFigure` class.
-
-    Parameters
-    ----------
-    row_start : int
-        The row where to set the upper-left corner of the SubFigure.
-    col_start : int
-        The column where to set the upper-left corner of the SubFigure.
-    row_span : int
-        The number of rows spanned by the SubFigure.
-    col_span : int
-        The number of columns spanned by the SubFigure.
-    x_label, y_label : str
-        The indentification for the x-axis and y-axis.
-        Defaults to ``"x axis"`` and ``"y axis"``.
-    title : str, optional
-        Title of the SubFigure.
-    x_lim, y_lim : tuple[float, float], optional
-        The limits for the x-axis and y-axis.
-    figure_style : str
-        The figure style to use for the figure.
-    add_reference_label : bool
-        Whether or not to add a reference label to the SubFigure.
-        Defaults to ``True``.
-    log_scale_x, log_scale_y : bool
-        Whether or not to set the scale of the x- or y-axis to logaritmic scale.
-        Default depends on the ``figure_style`` configuration.
-    show_grid : bool
-        Wheter or not to show the grid.
-        Default depends on the ``figure_style`` configuration.
-    remove_axes : bool
-        Whether or not to show the axes. Useful for adding tables or text to
-        the subfigure. Defaults to ``False``.
-    """
-
-    def __init__(
-        self,
-        row_start: int,
-        col_start: int,
-        row_span: int,
-        col_span: int,
-        x_label: str = "x axis",
-        y_label: str = "y axis",
-        title: Optional[str] = None,
-        x_lim: Optional[tuple[float, float]] = None,
-        y_lim: Optional[tuple[float, float]] = None,
-        figure_style: str = "plain",
-        add_reference_label: bool = True,
-        log_scale_x: bool | Literal["default"] = "default",
-        log_scale_y: bool | Literal["default"] = "default",
-        show_grid: bool | Literal["default"] = "default",
-        remove_axes: bool = False,
-    ):
-        """
-        This class implements the individual plots added inside the
-        :class:`~graphinglib.multifigure.MultiFigure` object.
-
-        .. attention::
-
-            This class is not meant to be used directly by the user. Instead, it is used in
-            conjunction with the :class:`~graphinglib.multifigure.MultiFigure` class.
-
-        Parameters
-        ----------
-        row_start : int
-            The row where to set the upper-left corner of the SubFigure.
-        col_start : int
-            The column where to set the upper-left corner of the SubFigure.
-        row_span : int
-            The number of rows spanned by the SubFigure.
-        col_span : int
-            The number of columns spanned by the SubFigure.
-        x_label, y_label : str
-            The indentification for the x-axis and y-axis.
-            Defaults to ``"x axis"`` and ``"y axis"``.
-        title : str, optional
-            Title of the SubFigure.
-        x_lim, y_lim : tuple[float, float], optional
-            The limits for the x-axis and y-axis.
-        figure_style : str
-            The figure style to use for the figure.
-        add_reference_label : bool
-            Whether or not to add a reference label to the SubFigure.
-            Defaults to ``True``.
-        log_scale_x, log_scale_y : bool
-            Whether or not to set the scale of the x- or y-axis to logaritmic scale.
-            Default depends on the ``figure_style`` configuration.
-        show_grid : bool
-            Wheter or not to show the grid.
-            Default depends on the ``figure_style`` configuration.
-        remove_axes : bool
-            Whether or not to show the axes. Useful for adding tables or text to
-            the subfigure. Defaults to ``False``.
-        """
-        self.x_axis_name = x_label
-        self.y_axis_name = y_label
-        self.title = title
-        self.x_lim = x_lim
-        self.y_lim = y_lim
-        self.row_start, self.col_start = row_start, col_start
-        self.row_span, self.col_span = row_span, col_span
-        self.figure_style = figure_style
-        self.log_scale_x = log_scale_x
-        self.log_scale_y = log_scale_y
-        if show_grid == "default":
-            self.show_grid = "unchanged"
-        else:
-            self.show_grid = show_grid
-        self.add_reference_label = add_reference_label
-        self.remove_axes = remove_axes
-        self._elements: list[Plottable] = []
-        self._labels: list[str | None] = []
-        self._handles = []
-        self._custom_ticks = False
-
-    def add_element(self, *elements: Plottable) -> None:
-        """
-        Adds a :class:`~graphinglib.graph_elements.Plottable` element to the
-        :class:`~graphinglib.multifigure.SubFigure`.
-
-        Parameters
-        ----------
-        elements : :class:`~graphinglib.graph_elements.Plottable`
-            Elements to plot in the :class:`~graphinglib.multifigure.SubFigure`.
-        """
-        for element in elements:
-            self._elements.append(element)
-
-    def _prepare_SubFigure(
-        self,
-        grid: GridSpec,
-        transformation: ScaledTranslation,
-        reference_label: str,
-        legend: bool = True,
-    ) -> Axes:
-        """
-        Prepares the :class:`~graphinglib.multifigure.SubFigure` to be displayed.
-        """
-        try:
-            file_loader = FileLoader(self.figure_style)
-            self.default_params = file_loader.load()
-            is_matplotlib_style = False
-        except FileNotFoundError:
-            try:
-                if self.figure_style == "matplotlib":
-                    plt.style.use("default")
-                else:
-                    plt.style.use(self.figure_style)
-                file_loader = FileLoader("plain")
-                self.default_params = file_loader.load()
-                is_matplotlib_style = True
-            except OSError:
-                raise GraphingException(
-                    f"The figure style {self.figure_style} was not found. Please choose a different style."
-                )
-        figure_params_to_reset = self._fill_in_missing_params(self)
-
-        self._axes = plt.subplot(
-            grid.new_subplotspec(
-                (self.row_start, self.col_start),
-                rowspan=self.row_span,
-                colspan=self.col_span,
-            )
-        )
-        if self.add_reference_label:
-            self._axes.text(
-                0,
-                1,
-                reference_label,
-                transform=self._axes.transAxes + transformation,
-            )
-        if self.show_grid == "unchanged":
-            pass
-        elif self.show_grid:
-            self._axes.grid(True)
-        else:
-            self._axes.grid(False)
-        self._axes.set_xlabel(self.x_axis_name)
-        self._axes.set_ylabel(self.y_axis_name)
-        if self.title:
-            self._axes.set_title(self.title)
-        if self._custom_ticks:
-            if self._xticks:
-                self._axes.set_xticks(self._xticks, self._xticklabels)
-            if self._yticks:
-                self._axes.set_yticks(self._yticks, self._yticklabels)
-        if self.x_lim:
-            self._axes.set_xlim(*self.x_lim)
-        if self.y_lim:
-            self._axes.set_ylim(*self.y_lim)
-        if self.log_scale_x:
-            self._axes.set_xscale("log")
-        if self.log_scale_y:
-            self._axes.set_yscale("log")
-        if self.remove_axes:
-            self._axes.axis("off")
-            warn(
-                "Axes on SubFigure placed at ({},{},{},{}) have been removed.".format(
-                    self.row_start, self.col_start, self.row_span, self.col_span
-                )
-            )
-        if self._elements:
-            z_order = 12
-            for element in self._elements:
-                if not is_matplotlib_style:
-                    params_to_reset = self._fill_in_missing_params(element)
-                element._plot_element(self._axes, z_order)
-                if not is_matplotlib_style:
-                    self._reset_params_to_default(element, params_to_reset)
-                try:
-                    if element.label is not None:
-                        self._handles.append(element.handle)
-                        self._labels.append(element.label)
-                except AttributeError:
-                    continue
-                z_order += 2
-            if not self._labels:
-                legend = False
-            if legend:
-                try:
-                    self._axes.legend(
-                        handles=self._handles,
-                        labels=self._labels,
-                        handleheight=1.3,
-                        handler_map={
-                            Polygon: HandlerPatch(patch_func=histogram_legend_artist),
-                            LineCollection: HandlerMultipleLines(),
-                            VerticalLineCollection: HandlerMultipleVerticalLines(),
-                        },
-                        draggable=True,
-                    )
-                except:
-                    self._axes.legend(
-                        handles=self._handles,
-                        labels=self._labels,
-                        handleheight=1.3,
-                        handler_map={
-                            Polygon: HandlerPatch(patch_func=histogram_legend_artist),
-                            LineCollection: HandlerMultipleLines(),
-                            VerticalLineCollection: HandlerMultipleVerticalLines(),
-                        },
-                    )
-        else:
-            raise GraphingException("No curves to be plotted!")
-        self._reset_params_to_default(self, figure_params_to_reset)
-        temp_labels, temp_handles = self._labels, self._handles
-        self._labels, self._handles = [], []
-        return temp_labels, temp_handles
-
-    def _fill_in_missing_params(self, element: Plottable) -> list[str]:
-        """
-        Fills in the missing parameters from the specified ``figure_style``.
-        """
-        params_to_reset = []
-        object_type = type(element).__name__
-        tries = 0
-        curve_defaults = {
-            "errorbars_color": "color",
-            "errorbars_line_width": "line_width",
-            "cap_thickness": "line_width",
-            "fill_under_color": "color",
-        }
-        while tries < 2:
-            try:
-                for property, value in vars(element).items():
-                    if type(value) == str and value == "default":
-                        params_to_reset.append(property)
-                        default_value = self.default_params[object_type][property]
-                        if default_value == "same as curve":
-                            setattr(
-                                element,
-                                property,
-                                getattr(element, curve_defaults[property]),
-                            )
-                        elif default_value == "same as scatter":
-                            element.errorbars_color = getattr(element, "face_color")
-                        else:
-                            setattr(element, property, default_value)
-                break
-            except KeyError as e:
-                tries += 1
-                if tries >= 2:
-                    raise GraphingException(
-                        f"There was an error auto updating your {self.figure_style} style file following the recent GraphingLib update. Please notify the developers by creating an issue on GraphingLib's GitHub page. In the meantime, you can manually add the following parameter to your {self.figure_style} style file:\n {object_type}.{e.args[0]}"
-                    )
-                file_updater = FileUpdater(self.figure_style)
-                print(object_type, e.args[0])
-                file_updater.update()
-                file_loader = FileLoader(self.figure_style)
-                self.default_params = file_loader.load()
-        return params_to_reset
-
-    def _reset_params_to_default(
-        self, element: Plottable, params_to_reset: list[str]
-    ) -> None:
-        """
-        Resets the parameters that were set to default in the _fill_in_missing_params method.
-        """
-        for param in params_to_reset:
-            setattr(element, param, "default")
-
-    def set_ticks(
-        self,
-        xticks: Optional[list[float]] = None,
-        xticklabels: Optional[list[str]] = None,
-        yticks: Optional[list[float]] = None,
-        yticklabels: Optional[list[str]] = None,
-    ):
-        """
-        Sets custom [x/y]ticks and [x/y]ticks' labels.
-
-        ..note::
-            [x/y]ticks and [x/y]ticks' labels can be omited as long as labels are provided for
-            specified ticks.
-
-        Parameters
-        ----------
-        xticks : list[float], optional
-            Tick positions for the x axis.
-        xticklabels : list[str], optional
-            Tick labels for the x axis.
-        yticks : list[float], optional
-            Tick positions for the y axis.
-        yticklabels : list[str], optional
-            Tick labels for the y axis.
-        """
-        self._custom_ticks = True
-        self._xticks = xticks
-        self._xticklabels = xticklabels
-        self._yticks = yticks
-        self._yticklabels = yticklabels
-        if self._xticks or self._yticks:
-            if self._yticks and not self._yticklabels:
-                raise GraphingException(
-                    "Ticks position and corresponding labels must both be specified for the y axis."
-                )
-            if self._xticks and not self._xticklabels:
-                raise GraphingException(
-                    "Ticks position and corresponding labels must both be specified for the x axis."
-                )
+from .figure import Figure
 
 
 class MultiFigure:
@@ -376,7 +26,7 @@ class MultiFigure:
     This class implements the "canvas" on which multiple plots are displayed.
 
     The canvas consists of a grid of a specified size on which the
-    :class:`~graphinglib.multifigure.SubFigure` objects are displayed.
+    :class:`~graphinglib.figure.Figure` objects are displayed.
 
     Parameters
     ----------
@@ -389,12 +39,12 @@ class MultiFigure:
             See :py:meth:`~graphinglib.multifigure.MultiFigure.add_SubFigure`.
 
     size : tuple[float, float]
-        Overall size of the figure.
+        Overall size of the multifigure.
         Default depends on the ``figure_style`` configuration.
     title : str, optional
         General title of the figure.
     reference_labels : bool
-        Wheter or not to add reference labels to the SubFigures.
+        Whether or not to add reference labels to the SubFigures.
         Defaults to ``True``.
 
         .. note::
@@ -466,31 +116,25 @@ class MultiFigure:
         self.reflabel_loc = reflabel_loc
         self.figure_style = figure_style
         self.size = size
-        self._SubFigures = []
+        self._sub_figures = []
         self._rc_dict = {}
         self._user_rc_dict = {}
 
-    def add_SubFigure(
+    def add_sub_figure(
         self,
+        sub_figure: Figure,
         row_start: int,
         col_start: int,
         row_span: int,
         col_span: int,
-        x_label: str = "x axis",
-        y_label: str = "y axis",
-        title: Optional[str] = None,
-        x_lim: Optional[tuple[float, float]] = None,
-        y_lim: Optional[tuple[float, float]] = None,
-        log_scale_x: bool | Literal["default"] = "default",
-        log_scale_y: bool | Literal["default"] = "default",
-        show_grid: bool | Literal["default"] = "default",
-        remove_axes: bool = False,
-    ) -> SubFigure:
+    ):
         """
         Adds a :class:`~graphinglib.multifigure.SubFigure` to a :class:`~graphinglib.multifigure.MultiFigure`.
 
         Parameters
         ----------
+        sub_figure : Figure
+            The :class:`~graphinglib.figure.Figure` to add to the MultiFigure.
         row_start : int
             The row where to set the upper-left corner of the SubFigure.
         col_start : int
@@ -499,27 +143,6 @@ class MultiFigure:
             The number of rows spanned by the SubFigure.
         col_span : int
             The number of columns spanned by the SubFigure.
-        x_label, y_label : str
-            The indentification for the x-axis and y-axis.
-            Defaults to ``"x axis"`` and ``"y axis"``.
-        title : str, optional
-            Title of the SubFigure.
-        x_lim, y_lim : tuple[float, float], optional
-            The limits for the x-axis and y-axis.
-        log_scale_x, log_scale_y : bool
-            Whether or not to set the scale of the x- or y-axis to logaritmic scale.
-            Default depends on the ``figure_style`` configuration.
-        show_grid : bool
-            Wheter or not to show the grid.
-            Default depends on the ``figure_style`` configuration.
-        remove_axes : bool
-            Whether or not to show the axes. Useful for adding tables or text to
-            the subfigure. Defaults to ``False``.
-
-        Returns
-        -------
-        new_SubFigure : :class:`~graphinglib.multifigure.SubFigure`
-            :class:`~graphinglib.multifigure.SubFigure` to be added to the :class:`~graphinglib.multifigure.MultiFigure`.
         """
 
         if type(row_start) != int or type(col_start) != int:
@@ -534,27 +157,76 @@ class MultiFigure:
             raise ValueError(
                 "The placement values and span values must be inside the size of the MultiFigure."
             )
-        new_SubFigure = SubFigure(
-            row_start,
-            col_start,
-            row_span,
-            col_span,
-            x_label,
-            y_label,
-            title,
-            x_lim,
-            y_lim,
-            self.figure_style,
-            self.reference_labels,
-            log_scale_x,
-            log_scale_y,
-            show_grid,
-            remove_axes,
-        )
-        self._SubFigures.append(new_SubFigure)
-        return new_SubFigure
+        # Add location and span to the SubFigure (create new attributes)
+        sub_figure.row_start = row_start
+        sub_figure.col_start = col_start
+        sub_figure.row_span = row_span
+        sub_figure.col_span = col_span
+        self._sub_figures.append(sub_figure)
 
-    def _prepare_MultiFigure(
+    def display(
+        self,
+        general_legend: bool = False,
+        legend_loc: str = "outside lower center",
+        legend_cols: int = 1,
+    ) -> None:
+        """
+        Displays the :class:`~graphinglib.multifigure.MultiFigure`.
+
+        Parameters
+        ----------
+        general_legend : bool
+            Wheter or not to display a overall legend for the :class:`~graphinglib.multifigure.MultiFigure` containing
+            the labels for every :class:`~graphinglib.multifigure.SubFigure` in it. Note that enabling this option will
+            disable the individual legends for every :class:`~graphinglib.multifigure.SubFigure`.
+            Defaults to ``False``.
+        legend_loc : str
+            The location of the legend in the MultiFigure. Possible placement keywords are: for vertical placement: ``{"upper", "center", "lower"}``, for horizontal placement: ``{"left", "center", "right"}``. The keyword ``"outside"`` can be added to put the legend outside of the axes. Defaults to ``"outside lower center"``.
+        legend_cols : int
+            Number of colums in which to arange the legend items. Defaults to 1.
+        """
+        self._prepare_multi_figure(
+            general_legend=general_legend,
+            legend_loc=legend_loc,
+            legend_cols=legend_cols,
+        )
+        plt.show()
+        plt.rcParams.update(rcParamsDefault)
+
+    def save_figure(
+        self,
+        file_name: str,
+        general_legend: bool = False,
+        legend_loc: str = "outside lower center",
+        legend_cols: int = 1,
+    ) -> None:
+        """
+        Saves the :class:`~graphinglib.multifigure.MultiFigure`.
+
+        Parameters
+        ----------
+        file_name : str
+            File name or path at which to save the figure.
+        general_legend : bool
+            Wheter or not to display a overall legend for the :class:`~graphinglib.multifigure.MultiFigure` containing
+            the labels for every :class:`~graphinglib.multifigure.SubFigure` in it. Note that enabling this option will
+            disable the individual legends for every :class:`~graphinglib.multifigure.SubFigure`.
+            Defaults to ``False``.
+        legend_loc : str
+            The location of the legend in the MultiFigure. Possible placement keywords are: for vertical placement: ``{"upper", "center", "lower"}``, for horizontal placement: ``{"left", "center", "right"}``. The keyword ``"outside"`` can be added to put the legend outside of the axes. Defaults to ``"outside lower center"``.
+        legend_cols : int
+            Number of colums in which to arange the legend items. Defaults to 1.
+        """
+        self._prepare_multi_figure(
+            general_legend=general_legend,
+            legend_loc=legend_loc,
+            legend_cols=legend_cols,
+        )
+        plt.savefig(file_name, bbox_inches="tight")
+        plt.close()
+        plt.rcParams.update(rcParamsDefault)
+
+    def _prepare_multi_figure(
         self,
         general_legend: bool = False,
         legend_loc: str = "outside lower center",
@@ -566,8 +238,9 @@ class MultiFigure:
         try:
             file_loader = FileLoader(self.figure_style)
             self.default_params = file_loader.load()
-            self._fill_in_rc_params()
+            is_matplotlib_style = False
         except FileNotFoundError:
+            is_matplotlib_style = True
             try:
                 if self.figure_style == "matplotlib":
                     plt.style.use("default")
@@ -582,6 +255,7 @@ class MultiFigure:
 
         multi_figure_params_to_reset = self._fill_in_missing_params(self)
 
+        self._fill_in_rc_params(is_matplotlib_style)
         self._figure = plt.figure(layout="constrained", figsize=self.size)
         MultiFigure_grid = GridSpec(self.num_rows, self.num_cols, figure=self._figure)
 
@@ -590,21 +264,26 @@ class MultiFigure:
         elif self.reflabel_loc == "inside":
             trans = ScaledTranslation(10 / 72, -15 / 72, self._figure.dpi_scale_trans)
         else:
-            raise ValueError("Invalid location parameter")
+            raise ValueError(
+                "Invalid reference label location. Please specify either 'inside' or 'outside'."
+            )
 
-        SubFigures_legend = True if not general_legend else False
+        sub_figures_do_legend = True if not general_legend else False
 
         labels, handles = [], []
-        for i, SubFigure in enumerate(self._SubFigures):
-            SubFigure.figure_style = self.figure_style
-            SubFigure_labels, SubFigure_handles = SubFigure._prepare_SubFigure(
+        for i, sub_figure in enumerate(self._sub_figures):
+            self._fill_in_rc_params(is_matplotlib_style)
+            sub_figure_labels, sub_figure_handles = self._prepare_sub_figure(
+                sub_figure,
                 MultiFigure_grid,
                 transformation=trans,
                 reference_label=ascii_lowercase[i] + ")",
-                legend=SubFigures_legend,
+                legend=sub_figures_do_legend,
+                is_matplotlib_style=is_matplotlib_style,
             )
-            labels += SubFigure_labels
-            handles += SubFigure_handles
+            labels += sub_figure_labels
+            handles += sub_figure_handles
+        self._fill_in_rc_params(is_matplotlib_style)
         if general_legend:
             try:
                 self._figure.legend(
@@ -637,67 +316,39 @@ class MultiFigure:
         self._reset_params_to_default(self, multi_figure_params_to_reset)
         self._rc_dict = {}
 
-    def display(
+    def _prepare_sub_figure(
         self,
-        general_legend: bool = False,
-        legend_loc: str = "outside lower center",
-        legend_cols: int = 1,
-    ) -> None:
-        """
-        Displays the :class:`~graphinglib.multifigure.MultiFigure`.
-
-        Parameters
-        ----------
-        general_legend : bool
-            Wheter or not to display a overall legend for the :class:`~graphinglib.multifigure.MultiFigure` containing
-            the labels for every :class:`~graphinglib.multifigure.SubFigure` in it. Note that enabling this option will
-            disable the individual legends for every :class:`~graphinglib.multifigure.SubFigure`.
-            Defaults to ``False``.
-        legend_loc : str
-            The location of the legend in the MultiFigure. Possible placement keywords are: for vertical placement: ``{"upper", "center", "lower"}``, for horizontal placement: ``{"left", "center", "right"}``. The keyword ``"outside"`` can be added to put the legend outside of the axes. Defaults to ``"outside lower center"``.
-        legend_cols : int
-            Number of colums in which to arange the legend items. Defaults to 1.
-        """
-        self._prepare_MultiFigure(
-            general_legend=general_legend,
-            legend_loc=legend_loc,
-            legend_cols=legend_cols,
+        sub_figure: Figure,
+        grid: GridSpec,
+        transformation: ScaledTranslation,
+        reference_label: str,
+        legend: bool,
+        is_matplotlib_style: bool,
+    ):
+        # Set rc for subfigure
+        sub_rcs = sub_figure._user_rc_dict
+        plt.rcParams.update(sub_rcs)
+        axes = plt.subplot(
+            grid.new_subplotspec(
+                (sub_figure.row_start, sub_figure.col_start),
+                rowspan=sub_figure.row_span,
+                colspan=sub_figure.col_span,
+            )
         )
-        plt.show()
-        plt.rcParams.update(rcParamsDefault)
-
-    def save_figure(
-        self,
-        file_name: str,
-        general_legend: bool = False,
-        legend_loc: str = "outside lower center",
-        legend_cols: int = 1,
-    ) -> None:
-        """
-        Saves the :class:`~graphinglib.multifigure.MultiFigure`.
-
-        Parameters
-        ----------
-        file_name : str
-            File name or path at which to save the figure.
-        general_legend : bool
-            Wheter or not to display a overall legend for the :class:`~graphinglib.multifigure.MultiFigure` containing
-            the labels for every :class:`~graphinglib.multifigure.SubFigure` in it. Note that enabling this option will
-            disable the individual legends for every :class:`~graphinglib.multifigure.SubFigure`.
-            Defaults to ``False``.
-        legend_loc : str
-            The location of the legend in the MultiFigure. Possible placement keywords are: for vertical placement: ``{"upper", "center", "lower"}``, for horizontal placement: ``{"left", "center", "right"}``. The keyword ``"outside"`` can be added to put the legend outside of the axes. Defaults to ``"outside lower center"``.
-        legend_cols : int
-            Number of colums in which to arange the legend items. Defaults to 1.
-        """
-        self._prepare_MultiFigure(
-            general_legend=general_legend,
-            legend_loc=legend_loc,
-            legend_cols=legend_cols,
+        if self.reference_labels:
+            axes.text(
+                0,
+                1,
+                reference_label,
+                transform=axes.transAxes + transformation,
+            )
+        labels, handles = sub_figure._prepare_figure(
+            legend=legend,
+            axes=axes,
+            default_params=self.default_params,
+            is_matplotlib_style=is_matplotlib_style,
         )
-        plt.savefig(file_name, bbox_inches="tight")
-        plt.close()
-        plt.rcParams.update(rcParamsDefault)
+        return labels, handles
 
     def _fill_in_missing_params(self, element: Plottable) -> list[str]:
         """
@@ -737,11 +388,29 @@ class MultiFigure:
         for param in params_to_reset:
             setattr(element, param, "default")
 
+    def _fill_in_rc_params(self, is_matplotlib_style: bool = False) -> None:
+        """
+        Fills in the missing rc parameters from the specified ``figure_style``.
+        """
+        if is_matplotlib_style:
+            plt.style.use(self.figure_style)
+            plt.rcParams.update(self._user_rc_dict)
+        else:
+            params = self.default_params["rc_params"]
+            for property, value in params.items():
+                # add to rc_dict if not already in there
+                if (property not in self._rc_dict) and (
+                    property not in self._user_rc_dict
+                ):
+                    self._rc_dict[property] = value
+            all_rc_params = {**self._rc_dict, **self._user_rc_dict}
+            plt.rcParams.update(all_rc_params)
+
     def update_rc_params(
         self,
         rc_params_dict: dict[str, str | float] = {},
         reset: bool = False,
-    ):
+    ) -> None:
         """
         Customize the visual style of the :class:`~graphinglib.figure.Figure`.
 
@@ -783,7 +452,7 @@ class MultiFigure:
         grid_line_width: float | None = None,
         grid_color: str | None = None,
         grid_alpha: float | None = None,
-    ):
+    ) -> None:
         """
         Customize the visual style of the :class:`~graphinglib.figure.Figure`.
 
@@ -880,15 +549,3 @@ class MultiFigure:
             key: value for key, value in rc_params_dict.items() if value is not None
         }
         self.update_rc_params(rc_params_dict, reset=reset)
-
-    def _fill_in_rc_params(self):
-        """
-        Fills in the missing rc parameters from the specified ``figure_style``.
-        """
-        params = self.default_params["rc_params"]
-        for property, value in params.items():
-            # add to rc_dict if not already in there
-            if property not in self._rc_dict:
-                self._rc_dict[property] = value
-        all_rc_params = {**self._rc_dict, **self._user_rc_dict}
-        plt.rcParams.update(all_rc_params)

--- a/graphinglib/shapes.py
+++ b/graphinglib/shapes.py
@@ -217,7 +217,7 @@ class Circle:
                 "alpha": self.fill_alpha,
                 "facecolor": self.color,
             }
-            params = {k: v for k, v in params.items() if v != None}
+            params = {k: v for k, v in params.items() if v != "default"}
             axes.fill_between(x, y, self.y_center, zorder=z_order, **params)
 
 

--- a/unit_testing/data_plotting_2d_test.py
+++ b/unit_testing/data_plotting_2d_test.py
@@ -1,8 +1,8 @@
 import unittest
-from matplotlib import contour
+
 import numpy as np
 
-from graphinglib.data_plotting_2d import Heatmap, Contour
+from graphinglib.data_plotting_2d import Contour, Heatmap
 from graphinglib.figure import Figure
 
 

--- a/unit_testing/figure_test.py
+++ b/unit_testing/figure_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+from matplotlib import pyplot as plt
 from numpy import linspace, pi, sin
 
 from graphinglib.data_plotting_1d import Curve
@@ -25,9 +26,16 @@ class TestFigure(unittest.TestCase):
     def test_handles_is_list(self):
         self.assertIsInstance(self.testFigure._handles, list)
 
-    def test_curve_is_added(self):
+    def test_add_element(self):
         self.testFigure.add_element(self.testCurve)
         self.assertIs(self.testFigure._elements[0], self.testCurve)
+        # Test if adding multiple elements works
+        other_curve = Curve(self.testCurve.x_data, self.testCurve.y_data, "Other Curve")
+        other_other_curve = Curve(
+            self.testCurve.x_data, self.testCurve.y_data, "Other Other Curve"
+        )
+        self.testFigure.add_element(other_curve, other_other_curve)
+        self.assertTrue(len(self.testFigure._elements), 3)
 
     def test_all_curves_plotted(self):
         self.testFigure.add_element(self.testCurve)
@@ -105,6 +113,94 @@ class TestFigure(unittest.TestCase):
         handles, labels = self.testFigure._axes.get_legend_handles_labels()
         self.assertEqual(len(handles), 2)
         self.assertListEqual(labels, ["Test Curve", "Other Curve"])
+
+    def test_fill_in_rc_params_gl(self):
+        a_figure = Figure()
+        a_figure.customize_visual_style(legend_edge_color="red")
+        # Get default params for dim style
+        a_figure.default_params = {
+            "rc_params": {
+                "axes.grid": False,
+                "axes.facecolor": "dimgrey",
+                "legend.edgecolor": "blue",
+            }
+        }
+        # Fill in rc params
+        a_figure._fill_in_rc_params()
+        # Check axes fill color is updated
+        self.assertEqual(plt.rcParams["axes.grid"], False)
+        self.assertEqual(plt.rcParams["axes.facecolor"], "dimgrey")
+        self.assertEqual(plt.rcParams["legend.edgecolor"], "red")  # Overridden by user
+
+    def test_update_rc_params(self):
+        a_figure = Figure()
+        params = {
+            "lines.linewidth": 2,
+            "axes.labelsize": 10,
+            "axes.titlesize": 10,
+        }
+        a_figure.update_rc_params(params)
+        self.assertDictEqual(a_figure._user_rc_dict, params)
+        more_params = {
+            "lines.linewidth": 3,
+            "axes.grid": True,
+        }
+        a_figure.update_rc_params(more_params)
+        resulting_params = {
+            "lines.linewidth": 3,
+            "axes.labelsize": 10,
+            "axes.titlesize": 10,
+            "axes.grid": True,
+        }
+        self.assertDictEqual(a_figure._user_rc_dict, resulting_params)
+
+    def test_update_rc_params_reset(self):
+        a_figure = Figure()
+        params = {
+            "lines.linewidth": 2,
+            "axes.labelsize": 10,
+            "axes.titlesize": 10,
+        }
+        a_figure.update_rc_params(params)
+        a_figure.update_rc_params({"lines.linewidth": 3}, reset=True)
+        self.assertDictEqual(a_figure._user_rc_dict, {"lines.linewidth": 3})
+
+    def test_customize_visual_style(self):
+        a_figure = Figure()
+        a_figure.customize_visual_style(
+            figure_face_color="red", axes_face_color="blue", grid_line_style="dashed"
+        )
+        self.assertDictEqual(
+            a_figure._user_rc_dict,
+            {
+                "figure.facecolor": "red",
+                "axes.facecolor": "blue",
+                "grid.linestyle": "dashed",
+            },
+        )
+        a_figure.customize_visual_style(
+            axes_face_color="yellow", grid_line_style="dotted", x_tick_color="green"
+        )
+        self.assertDictEqual(
+            a_figure._user_rc_dict,
+            {
+                "figure.facecolor": "red",
+                "axes.facecolor": "yellow",
+                "grid.linestyle": "dotted",
+                "xtick.color": "green",
+            },
+        )
+
+    def test_customize_visual_style_reset(self):
+        a_figure = Figure()
+        a_figure.customize_visual_style(
+            figure_face_color="red", axes_face_color="blue", grid_line_style="dashed"
+        )
+        a_figure.customize_visual_style(
+            axes_face_color="yellow", grid_line_style="dotted", x_tick_color="green"
+        )
+        a_figure.customize_visual_style(reset=True)
+        self.assertDictEqual(a_figure._user_rc_dict, {})
 
 
 if __name__ == "__main__":

--- a/unit_testing/figure_test.py
+++ b/unit_testing/figure_test.py
@@ -105,3 +105,7 @@ class TestFigure(unittest.TestCase):
         handles, labels = self.testFigure._axes.get_legend_handles_labels()
         self.assertEqual(len(handles), 2)
         self.assertListEqual(labels, ["Test Curve", "Other Curve"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_testing/figure_test.py
+++ b/unit_testing/figure_test.py
@@ -202,6 +202,11 @@ class TestFigure(unittest.TestCase):
         a_figure.customize_visual_style(reset=True)
         self.assertDictEqual(a_figure._user_rc_dict, {})
 
+    def test_matplotlib_style_functional(self):
+        a_figure = Figure(figure_style="matplotlib")
+        a_figure.add_element(self.testCurve)
+        a_figure._prepare_figure()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/unit_testing/multifigure_test.py
+++ b/unit_testing/multifigure_test.py
@@ -258,6 +258,18 @@ class TestMultiFigure(unittest.TestCase):
         a_multifigure.customize_visual_style(reset=True)
         self.assertDictEqual(a_multifigure._user_rc_dict, {})
 
+    def test_matplotlib_style_functional(self):
+        a_figure = Figure()
+        curve = Curve([1, 2, 3], [1, 2, 3])
+        curve2 = Curve([1, 2, 3], [1, 2, 3], line_width=5)
+        a_figure.add_element(curve)
+        another_figure = Figure()
+        another_figure.add_element(curve2)
+        a_multifig = MultiFigure.stack(
+            [a_figure, another_figure], figure_style="matplotlib"
+        )
+        a_multifig._prepare_multi_figure()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/unit_testing/multifigure_test.py
+++ b/unit_testing/multifigure_test.py
@@ -2,7 +2,7 @@ import unittest
 
 from graphinglib.data_plotting_1d import Curve
 from graphinglib.file_manager import FileLoader
-from graphinglib.multifigure import MultiFigure, SubFigure
+from graphinglib.multifigure import MultiFigure
 
 
 class TestMultiFigure(unittest.TestCase):

--- a/unit_testing/multifigure_test.py
+++ b/unit_testing/multifigure_test.py
@@ -1,21 +1,36 @@
 import unittest
 
 from graphinglib.data_plotting_1d import Curve
+from graphinglib.figure import Figure
 from graphinglib.file_manager import FileLoader
 from graphinglib.multifigure import MultiFigure
 
 
 class TestMultiFigure(unittest.TestCase):
-    def setUp(self):
-        self.test_curve = Curve.from_function(lambda x: x**2, 0, 10, "Test Curve")
-        self.small_multifigure = MultiFigure(1, 1)
-        self.big_multifigure = MultiFigure(4, 4)
-
     def test_create_multifigure(self):
         a_multifig = MultiFigure(num_rows=2, num_cols=2)
         self.assertEqual(a_multifig.num_rows, 2)
         self.assertEqual(a_multifig.num_cols, 2)
 
+        another_multifig = MultiFigure(
+            num_rows=2,
+            num_cols=2,
+            size=(5, 5),
+            title="Test Title",
+            reference_labels=False,
+            reflabel_loc="inside",
+            figure_style="plain",
+        )
+        self.assertEqual(another_multifig.size, (5, 5))
+        self.assertEqual(another_multifig.title, "Test Title")
+        self.assertEqual(another_multifig.reference_labels, False)
+        self.assertEqual(another_multifig.reflabel_loc, "inside")
+        self.assertEqual(another_multifig.figure_style, "plain")
+        self.assertListEqual(another_multifig._sub_figures, [])
+        self.assertDictEqual(another_multifig._rc_dict, {})
+        self.assertDictEqual(another_multifig._user_rc_dict, {})
+
+    def test_create_multifigure_raises(self):
         # Test that raises error if num_rows or num_cols is not an integer or is less than 1
         with self.assertRaises(TypeError):
             MultiFigure(num_rows=2.5, num_cols=2)
@@ -24,167 +39,173 @@ class TestMultiFigure(unittest.TestCase):
         with self.assertRaises(ValueError):
             MultiFigure(num_rows=2, num_cols=0)
 
-    def test_create_subfigure(self):
-        self.small_multifigure.add_SubFigure(
-            row_start=0, col_start=0, row_span=1, col_span=1
-        )
+    def test_add_sub_figure(self):
+        a_figure = Figure()
+        a_multifig = MultiFigure(num_rows=2, num_cols=2)
+        a_multifig.add_sub_figure(a_figure, 0, 0, 1, 1)
+        self.assertEqual(a_multifig._sub_figures[0], a_figure)
+        self.assertEqual(a_figure.row_start, 0)
+        self.assertEqual(a_figure.row_span, 1)
+        self.assertEqual(a_figure.col_start, 0)
+        self.assertEqual(a_figure.col_span, 1)
 
-    def test_create_subfigure_wrong_span(self):
-        # Test that raises error if row_start or col_start is not an integer or is less than 0
+        another_figure = Figure()
+        a_multifig.add_sub_figure(another_figure, 1, 1, 1, 1)
+        self.assertEqual(a_multifig._sub_figures[1], another_figure)
+        self.assertEqual(another_figure.row_start, 1)
+        self.assertEqual(another_figure.row_span, 1)
+        self.assertEqual(another_figure.col_start, 1)
+        self.assertEqual(another_figure.col_span, 1)
+
+    def test_add_sub_figure_raises(self):
+        a_figure = Figure()
+        a_multifig = MultiFigure(num_rows=2, num_cols=2)
         with self.assertRaises(TypeError):
-            self.small_multifigure.add_SubFigure(
-                row_start=0.5, col_start=0, row_span=1, col_span=1
-            )
-        with self.assertRaises(ValueError):
-            self.small_multifigure.add_SubFigure(
-                row_start=-1, col_start=0, row_span=1, col_span=1
-            )
-        with self.assertRaises(TypeError):
-            self.small_multifigure.add_SubFigure(
-                row_start=0, col_start=0.5, row_span=1, col_span=1
-            )
+            a_multifig.add_sub_figure(a_figure, 0.5, 0, 1, 1)
 
-    def test_create_subfigure_span_too_high(self):
-        # Test that raises error if row_span or col_span is greater than or equal to num_rows or num_cols
         with self.assertRaises(ValueError):
-            self.small_multifigure.add_SubFigure(
-                row_start=0, col_start=0, row_span=2, col_span=1
-            )
-        with self.assertRaises(ValueError):
-            self.small_multifigure.add_SubFigure(
-                row_start=0, col_start=0, row_span=1, col_span=2
-            )
+            a_multifig.add_sub_figure(a_figure, 0, 2, 1, 1)
 
-    def test_create_subfigure_start_too_high(self):
-        # Test that raises error if row_start or col_start is greater than or equal to num_rows or num_cols
         with self.assertRaises(ValueError):
-            self.small_multifigure.add_SubFigure(
-                row_start=1, col_start=0, row_span=1, col_span=1
-            )
+            a_multifig.add_sub_figure(a_figure, 0, 0, 0, 1)
+
         with self.assertRaises(ValueError):
-            self.small_multifigure.add_SubFigure(
-                row_start=0, col_start=1, row_span=1, col_span=1
-            )
+            a_multifig.add_sub_figure(a_figure, 0, 0, 1, 0)
 
-    def test_fill_in_missing_params_plain(self):
-        # Fill in values for plain style
-        self.small_multifigure.add_SubFigure(
-            row_start=0, col_start=0, row_span=1, col_span=1
-        )
-        self.small_multifigure.default_params = FileLoader("plain").load()
-        self.small_multifigure._fill_in_missing_params(self.small_multifigure)
-        self.assertListEqual(self.small_multifigure.size, [6.4, 4.8])
+        with self.assertRaises(ValueError):
+            a_multifig.add_sub_figure(a_figure, 0, 0, 3, 1)
 
-    def test_fill_in_missing_params_horrible(self):
-        # Fill in values for horrible style
-        self.small_multifigure.add_SubFigure(
-            row_start=0, col_start=0, row_span=1, col_span=1
-        )
-        self.small_multifigure.default_params = FileLoader("horrible").load()
-        self.small_multifigure._fill_in_missing_params(self.small_multifigure)
-        self.assertEqual(self.small_multifigure.size, [10, 7])
+        with self.assertRaises(ValueError):
+            a_multifig.add_sub_figure(a_figure, 0, 0, 1, 3)
+
+    def test_stack(self):
+        a_figure = Figure()
+        another_figure = Figure()
+        a_multifig = MultiFigure.stack([a_figure, another_figure])
+        self.assertEqual(a_multifig.num_rows, 2)
+        self.assertEqual(a_multifig.num_cols, 1)
+        self.assertEqual(a_multifig._sub_figures[0], a_figure)
+        self.assertEqual(a_multifig._sub_figures[1], another_figure)
+
+        self.assertEqual(a_figure.row_start, 0)
+        self.assertEqual(a_figure.row_span, 1)
+        self.assertEqual(a_figure.col_start, 0)
+        self.assertEqual(a_figure.col_span, 1)
+
+        self.assertEqual(another_figure.row_start, 1)
+        self.assertEqual(another_figure.row_span, 1)
+        self.assertEqual(another_figure.col_start, 0)
+        self.assertEqual(another_figure.col_span, 1)
+
+    def test_row(self):
+        a_figure = Figure()
+        another_figure = Figure()
+        a_multifig = MultiFigure.row([a_figure, another_figure])
+        self.assertEqual(a_multifig.num_rows, 1)
+        self.assertEqual(a_multifig.num_cols, 2)
+        self.assertEqual(a_multifig._sub_figures[0], a_figure)
+        self.assertEqual(a_multifig._sub_figures[1], another_figure)
+
+        self.assertEqual(a_figure.row_start, 0)
+        self.assertEqual(a_figure.row_span, 1)
+        self.assertEqual(a_figure.col_start, 0)
+        self.assertEqual(a_figure.col_span, 1)
+
+        self.assertEqual(another_figure.row_start, 0)
+        self.assertEqual(another_figure.row_span, 1)
+        self.assertEqual(another_figure.col_start, 1)
+        self.assertEqual(another_figure.col_span, 1)
+
+    def test_prepare_multifigure(self):
+        # TODO: Test this
+        pass
+
+    def test_prepare_sub_figure(self):
+        # TODO: Test this
+        pass
+
+    def test_fill_in_missing_params(self):
+        # TODO: Test this
+        pass
 
     def test_reset_params_to_default(self):
-        self.small_multifigure.add_SubFigure(
-            row_start=0, col_start=0, row_span=1, col_span=1
+        # TODO: Test this
+        pass
+
+    def test_fill_in_rc_params(self):
+        # TODO: Test this
+        pass
+
+    def test_update_rc_params(self):
+        a_multifigure = MultiFigure(num_rows=2, num_cols=2)
+        params = {
+            "lines.linewidth": 2,
+            "axes.labelsize": 10,
+            "axes.titlesize": 10,
+        }
+        a_multifigure.update_rc_params(params)
+        self.assertDictEqual(a_multifigure._user_rc_dict, params)
+        more_params = {
+            "lines.linewidth": 3,
+            "axes.grid": True,
+        }
+        a_multifigure.update_rc_params(more_params)
+        resulting_params = {
+            "lines.linewidth": 3,
+            "axes.labelsize": 10,
+            "axes.titlesize": 10,
+            "axes.grid": True,
+        }
+        self.assertDictEqual(a_multifigure._user_rc_dict, resulting_params)
+
+    def test_update_rc_params_reset(self):
+        a_multifigure = MultiFigure(num_rows=2, num_cols=2)
+        params = {
+            "lines.linewidth": 2,
+            "axes.labelsize": 10,
+            "axes.titlesize": 10,
+        }
+        a_multifigure.update_rc_params(params)
+        a_multifigure.update_rc_params({"lines.linewidth": 3}, reset=True)
+        self.assertDictEqual(a_multifigure._user_rc_dict, {"lines.linewidth": 3})
+
+    def test_customize_visual_style(self):
+        a_multifigure = MultiFigure(num_rows=2, num_cols=2)
+        a_multifigure.customize_visual_style(
+            figure_face_color="red", axes_face_color="blue", grid_line_style="dashed"
         )
-        self.small_multifigure.default_params = FileLoader("plain").load()
-        params = self.small_multifigure._fill_in_missing_params(self.small_multifigure)
-        self.small_multifigure._reset_params_to_default(self.small_multifigure, params)
-        self.assertEqual(self.small_multifigure.size, "default")
-
-
-class TestSubFigure(unittest.TestCase):
-    def setUp(self) -> None:
-        self.test_curve = Curve.from_function(lambda x: x**2, 0, 10, "Test Curve")
-        self.other_curve = Curve.from_function(lambda x: x**3, 0, 10, "Other Curve")
-        self.subfigure = SubFigure(0, 0, 1, 1)
-
-    def test_add_element(self):
-        self.subfigure.add_element(self.test_curve)
-        self.assertEqual(self.subfigure._elements[0], self.test_curve)
-
-        # Add multiple elements
-        self.subfigure.add_element(self.other_curve, self.test_curve)
-        self.assertListEqual(
-            self.subfigure._elements,
-            [self.test_curve, self.other_curve, self.test_curve],
+        self.assertDictEqual(
+            a_multifigure._user_rc_dict,
+            {
+                "figure.facecolor": "red",
+                "axes.facecolor": "blue",
+                "grid.linestyle": "dashed",
+            },
+        )
+        a_multifigure.customize_visual_style(
+            axes_face_color="yellow", grid_line_style="dotted", x_tick_color="green"
+        )
+        self.assertDictEqual(
+            a_multifigure._user_rc_dict,
+            {
+                "figure.facecolor": "red",
+                "axes.facecolor": "yellow",
+                "grid.linestyle": "dotted",
+                "xtick.color": "green",
+            },
         )
 
-    def test_fill_in_missing_params_plain(self):
-        self.subfigure.default_params = FileLoader("plain").load()
-        self.subfigure._fill_in_missing_params(self.subfigure)
-        self.assertEqual(self.subfigure.log_scale_x, False)
-
-    def test_fill_in_missing_params_curve(self):
-        self.subfigure.add_element(self.test_curve)
-        self.subfigure.default_params = FileLoader("plain").load()
-        self.subfigure._fill_in_missing_params(self.test_curve)
-        self.assertEqual(self.test_curve.line_style, "-")
-        self.assertEqual(self.test_curve.line_width, 2)
-
-    def test_fill_in_missing_params_horrible(self):
-        self.subfigure.default_params = FileLoader("horrible").load()
-        self.subfigure._fill_in_missing_params(self.subfigure)
-        self.assertEqual(self.subfigure.log_scale_x, False)
-
-    def test_dont_overwrite_specified_params(self):
-        self.subfigure.show_grid = False
-        self.subfigure.default_params = FileLoader("horrible").load()
-        self.subfigure._fill_in_missing_params(self.subfigure)
-        self.assertEqual(self.subfigure.show_grid, False)
-
-    def test_dont_overwrite_specified_params_curve(self):
-        self.test_curve.line_style = "--"
-        self.test_curve.line_width = 3
-        self.subfigure.add_element(self.test_curve)
-        self.subfigure.default_params = FileLoader("plain").load()
-        self.subfigure._fill_in_missing_params(self.test_curve)
-        self.assertEqual(self.test_curve.line_style, "--")
-        self.assertEqual(self.test_curve.line_width, 3)
-
-    def test_reset_params_to_default(self):
-        self.subfigure.default_params = FileLoader("plain").load()
-        params = self.subfigure._fill_in_missing_params(self.subfigure)
-        self.subfigure._reset_params_to_default(self.subfigure, params)
-        self.assertEqual(self.subfigure.log_scale_x, "default")
-
-    def test_raise_exception_if_no_element_added(self):
-        multifig = MultiFigure(1, 1)
-        multifig.add_SubFigure(0, 0, 1, 1)
-        with self.assertRaises(Exception):
-            multifig._prepare_MultiFigure()
-
-    def test_all_curves_plotted(self):
-        multifig = MultiFigure(1, 1)
-        sub1 = multifig.add_SubFigure(0, 0, 1, 1)
-        sub1.add_element(self.test_curve)
-        multifig._prepare_MultiFigure()
-        self.assertEqual(len(sub1._axes.get_lines()), len(sub1._elements))
-
-    def test_handles_and_labels_cleared(self):
-        multifig = MultiFigure(1, 1)
-        sub1 = multifig.add_SubFigure(row_start=0, col_start=0, row_span=1, col_span=1)
-        sub1.add_element(self.test_curve)
-        multifig._prepare_MultiFigure()
-        self.assertEqual(len(sub1._handles), 0)
-        self.assertEqual(len(sub1._labels), 0)
-
-    def test_handles_and_labels_added(self):
-        multifig = MultiFigure(1, 1)
-        sub1 = multifig.add_SubFigure(row_start=0, col_start=0, row_span=1, col_span=1)
-        sub1.add_element(self.test_curve)
-        other_curve = Curve(
-            self.test_curve.x_data, self.test_curve.y_data, "Other Curve"
+    def test_customize_visual_style_reset(self):
+        a_multifigure = MultiFigure(num_rows=2, num_cols=2)
+        a_multifigure.customize_visual_style(
+            figure_face_color="red", axes_face_color="blue", grid_line_style="dashed"
         )
-        sub1.add_element(other_curve)
-        multifig._prepare_MultiFigure()
-        handles, labels = sub1._axes.get_legend_handles_labels()
-        self.assertEqual(len(handles), 2)
-        self.assertListEqual(labels, ["Test Curve", "Other Curve"])
-        # test if still ok when replotting
-        multifig.figure_style = "horrible"
-        multifig._prepare_MultiFigure()
-        handles, labels = sub1._axes.get_legend_handles_labels()
-        self.assertEqual(len(handles), 2)
-        self.assertListEqual(labels, ["Test Curve", "Other Curve"])
+        a_multifigure.customize_visual_style(
+            axes_face_color="yellow", grid_line_style="dotted", x_tick_color="green"
+        )
+        a_multifigure.customize_visual_style(reset=True)
+        self.assertDictEqual(a_multifigure._user_rc_dict, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## PR summary
Closes issue #312.
Major change to Figure/MultiFigure api and background functioning. Main points:
- No more SubFigure class
- MultiFigures are created from a collection of Figure objects.
- Both the individual figures and the multifigure created from the ind. figs. can be displayed
- In multifigures, the figure_style used is that of the MultiFigure (ind. fig. figure styles are ignored)
- All methods for settings rc_params are set for the multifigure first, then for each of the sub figures. This means that any deviations from the overall figure style is possible, and in case of double specification (say, grid on for figure and grid off for multifigure), the individual figure's rc params are always preferred (and the multifigure's rc params act as default values)

## PR checklist

- [x] Links to the related issue (#....)
- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete and documentation modified
- [x] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [x] If new files have been added, make sure they aren't excluded by .gitignore
- [x] Any new data files have been added to manifest.in
