### PR TITLE
325 feature request add grid option to multifigure

### DIFF
--- a/graphinglib/data_plotting_1d.py
+++ b/graphinglib/data_plotting_1d.py
@@ -1479,15 +1479,22 @@ class Histogram:
             num_of_points = 500
             x_data = np.linspace(self._bin_edges[0], self._bin_edges[-1], num_of_points)
             y_data = normal(x_data)
+            params = {
+                "color": self.pdf_curve_color,
+            }
+            params = {k: v for k, v in params.items() if v != "default"}
             axes.plot(
                 x_data,
                 y_data,
-                color=self.pdf_curve_color,
                 zorder=z_order,
+                **params,
             )
             curve_max_y = normal(self.mean)
             curve_std_y = normal(self.mean + self.standard_deviation)
             if self.pdf_show_std:
+                params = {}
+                if self.pdf_std_color != "default":
+                    params["colors"] = [self.pdf_std_color, self.pdf_std_color]
                 plt.vlines(
                     [
                         self.mean - self.standard_deviation,
@@ -1496,17 +1503,20 @@ class Histogram:
                     [0, 0],
                     [curve_std_y, curve_std_y],
                     linestyles=["dashed"],
-                    colors=[self.pdf_std_color, self.pdf_std_color],
                     zorder=z_order - 1,
+                    **params,
                 )
             if self.pdf_show_mean:
+                params = {}
+                if self.pdf_mean_color != "default":
+                    params["colors"] = [self.pdf_mean_color]
                 plt.vlines(
                     self.mean,
                     0,
                     curve_max_y,
                     linestyles=["dashed"],
-                    colors=[self.pdf_mean_color],
                     zorder=z_order - 1,
+                    **params,
                 )
 
     def show_pdf(

--- a/graphinglib/multifigure.py
+++ b/graphinglib/multifigure.py
@@ -218,6 +218,65 @@ class MultiFigure:
             multi_fig.add_sub_figure(figure, i, 0, 1, 1)
         return multi_fig
 
+    @classmethod
+    def grid(
+        cls,
+        figures: list[Figure],
+        dimensions: tuple[int, int],
+        size: tuple[float, float] | Literal["default"] = "default",
+        title: Optional[str] = None,
+        reference_labels: bool = True,
+        reflabel_loc: str = "outside",
+        figure_style: str = "plain",
+    ) -> Self:
+        """Creates a MultiFigure with the specified :class:`~graphinglib.figure.Figure` objects in a grid configuration.
+
+        Parameters
+        ----------
+        figures : list[Figure]
+            The :class:`~graphinglib.figure.Figure` objects to add to the MultiFigure, from top-left to bottom-right.
+        dimensions : tuple[int, int]
+            The number of rows and columns of the grid (product should equal the number of figures).
+        size : tuple[float, float]
+            Overall size of the figure.
+            Default depends on the ``figure_style`` configuration.
+        title : str, optional
+            Title of the MultiFigure.
+            Defaults to ``None``.
+        reference_labels : bool
+            Whether or not to add reference labels to the SubFigures.
+            Defaults to ``True``.
+        reflabel_loc : str
+            Location of the reference labels of the SubFigures. Either "inside" or "outside".
+            Defaults to "outside".
+        figure_style : str
+            The figure style to use for the figure.
+            Defaults to "plain".
+
+        Returns
+        -------
+        A new MultiFigure object.
+        """
+        num_rows, num_cols = dimensions
+        if num_rows * num_cols < len(figures):
+            raise ValueError(
+                f"The product of the dimensions ({num_rows} x {num_cols}) must be greater than or equal to the number of figures ({len(figures)})."
+            )
+        multi_fig = cls(
+            num_rows=num_rows,
+            num_cols=num_cols,
+            size=size,
+            title=title,
+            reference_labels=reference_labels,
+            reflabel_loc=reflabel_loc,
+            figure_style=figure_style,
+        )
+        for i, figure in enumerate(figures):
+            row = i // num_cols
+            col = i % num_cols
+            multi_fig.add_sub_figure(figure, row, col, 1, 1)
+        return multi_fig
+
     def add_sub_figure(
         self,
         sub_figure: Figure,

--- a/unit_testing/multifigure_test.py
+++ b/unit_testing/multifigure_test.py
@@ -120,6 +120,89 @@ class TestMultiFigure(unittest.TestCase):
         self.assertEqual(another_figure.col_start, 1)
         self.assertEqual(another_figure.col_span, 1)
 
+    def test_grid(self):
+        fig1 = Figure()
+        fig2 = Figure()
+        fig3 = Figure()
+        fig4 = Figure()
+        fig5 = Figure()
+        fig6 = Figure()
+        a_multifig = MultiFigure.grid(
+            figures=[fig1, fig2, fig3, fig4, fig5, fig6],
+            dimensions=(2, 3),
+            size=(12, 8),
+            title="Complex Example",
+        )
+        self.assertEqual(a_multifig.num_rows, 2)
+        self.assertEqual(a_multifig.num_cols, 3)
+        self.assertEqual(a_multifig._sub_figures[0], fig1)
+        self.assertEqual(a_multifig._sub_figures[1], fig2)
+        self.assertEqual(a_multifig._sub_figures[2], fig3)
+        self.assertEqual(a_multifig._sub_figures[3], fig4)
+        self.assertEqual(a_multifig._sub_figures[4], fig5)
+        self.assertEqual(a_multifig._sub_figures[5], fig6)
+
+        self.assertEqual(fig1.row_start, 0)
+        self.assertEqual(fig1.row_span, 1)
+        self.assertEqual(fig1.col_start, 0)
+        self.assertEqual(fig1.col_span, 1)
+
+        self.assertEqual(fig2.row_start, 0)
+        self.assertEqual(fig2.row_span, 1)
+        self.assertEqual(fig2.col_start, 1)
+        self.assertEqual(fig2.col_span, 1)
+
+        self.assertEqual(fig3.row_start, 0)
+        self.assertEqual(fig3.row_span, 1)
+        self.assertEqual(fig3.col_start, 2)
+        self.assertEqual(fig3.col_span, 1)
+
+        self.assertEqual(fig4.row_start, 1)
+        self.assertEqual(fig4.row_span, 1)
+        self.assertEqual(fig4.col_start, 0)
+        self.assertEqual(fig4.col_span, 1)
+
+        self.assertEqual(fig5.row_start, 1)
+        self.assertEqual(fig5.row_span, 1)
+        self.assertEqual(fig5.col_start, 1)
+        self.assertEqual(fig5.col_span, 1)
+
+        self.assertEqual(fig6.row_start, 1)
+        self.assertEqual(fig6.row_span, 1)
+        self.assertEqual(fig6.col_start, 2)
+        self.assertEqual(fig6.col_span, 1)
+
+    def test_grid_raises(self):
+        # Grid too small
+        fig1 = Figure()
+        fig2 = Figure()
+        fig3 = Figure()
+        fig4 = Figure()
+        fig5 = Figure()
+        fig6 = Figure()
+        with self.assertRaises(ValueError):
+            MultiFigure.grid(
+                figures=[fig1, fig2, fig3, fig4, fig5, fig6],
+                dimensions=(2, 2),
+                size=(12, 8),
+                title="Complex Example",
+            )
+        with self.assertRaises(ValueError):
+            MultiFigure.grid(
+                figures=[fig1, fig2, fig3, fig4, fig5],
+                dimensions=(2, 1),
+                size=(12, 8),
+                title="Complex Example",
+            )
+        # Not integer dimensions
+        with self.assertRaises(TypeError):
+            MultiFigure.grid(
+                figures=[fig1, fig2, fig3, fig4, fig5],
+                dimensions=(2.5, 10),
+                size=(12, 8),
+                title="Complex Example",
+            )
+
     def test_prepare_multifigure_raises(self):
         a_multifig = MultiFigure(num_rows=2, num_cols=2, figure_style="Burrrd")
         with self.assertRaises(GraphingException):


### PR DESCRIPTION
## PR summary
Closes issue #325. MultiFigure.grid takes in a tuple (2,3) whose dimensions are at least as big as the number of Figures passed in, and the Figures are inserted into the grid in the order they are passed (inserted left to right, top to bottom).

## PR checklist

- [x] Links to the related issue (#....)
- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete and documentation modified
- [x] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [x] If new files have been added, make sure they aren't excluded by .gitignore
- [x] Any new data files have been added to manifest.in
