### PR TITLE
Fixed bug where rc params weren't set when passed to prepare_figure

### DIFF
--- a/graphinglib/figure.py
+++ b/graphinglib/figure.py
@@ -127,6 +127,7 @@ class Figure:
         """
         if default_params is not None:
             self.default_params = default_params
+            self._fill_in_rc_params()
             figure_params_to_reset = self._fill_in_missing_params(self)
         else:
             try:


### PR DESCRIPTION
## PR summary
Closes issue #372.

## PR checklist

- [x] Links to the related issue (#....)
- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete and documentation modified
- [x] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [x] If new files have been added, make sure they aren't excluded by .gitignore
- [x] Any new data files have been added to manifest.in
