### PR TITLE
Increased first plottable zorder to 2

### DIFF
--- a/graphinglib/figure.py
+++ b/graphinglib/figure.py
@@ -233,7 +233,7 @@ class Figure:
             self._handles += handles
             self._labels += labels
         if self._elements:
-            z_order = 1
+            z_order = 2
             for element in self._elements:
                 params_to_reset = []
                 if not is_matplotlib_style:


### PR DESCRIPTION
## PR summary
Increased the first plottable object's zorder from 1 to 2 so that the plottable is always over the grid lines. Closes #461 

## PR checklist

- [X] Links to the related issue (#....)
- [X] Units tests have been run and/or modified and/or added
- [X] Docstrings are complete and documentation modified
- [X] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [X] If new files have been added, make sure they aren't excluded by .gitignore
- [X] Any new data files have been added to manifest.in
