### PR TITLE
Fixed bug with scatter errorbars color default fetching

### DIFF
--- a/graphinglib/data_plotting_1d.py
+++ b/graphinglib/data_plotting_1d.py
@@ -1527,7 +1527,7 @@ class Scatter:
         self._errorbars_line_width: float = 1.0
         self._cap_width: float = 3.0
         self._cap_thickness: float = 1.0
-        self._errorbars_color: str = "default"
+        self._errorbars_color: Optional[str] = None
 
     @classmethod
     def from_function(
@@ -1584,7 +1584,15 @@ class Scatter:
         x_data = np.linspace(x_min, x_max, number_of_points)
         y_data = func(x_data)
         return cls(
-            x_data, y_data, label, face_color, edge_color, color_map, show_color_bar, marker_size, marker_style
+            x_data,
+            y_data,
+            label,
+            face_color,
+            edge_color,
+            color_map,
+            show_color_bar,
+            marker_size,
+            marker_style,
         )
 
     @property
@@ -2303,23 +2311,25 @@ class Scatter:
                 "capsize": self._cap_width,
                 "capthick": self._cap_thickness,
                 "ecolor": self._errorbars_color,
-                "linestyle": "none"
+                "linestyle": "none",
             }
-            errorbar_params = {k: v for k, v in errorbar_params.items() if v != "default"}
+            errorbar_params = {
+                k: v for k, v in errorbar_params.items() if v != "default"
+            }
             self.errorbars_handle = axes.errorbar(
                 self._x_data,
                 self._y_data,
                 xerr=self._x_error,
                 yerr=self._y_error,
                 zorder=z_order,
-                **errorbar_params
+                **errorbar_params,
             )
 
         params = {
             "edgecolors": self._edge_color,
             "s": self._marker_size,
             "marker": self._marker_style,
-            "cmap" : self._color_map if not isinstance(self._face_color, str) else None
+            "cmap": self._color_map if not isinstance(self._face_color, str) else None,
         }
         if params["marker"] == "default":
             params["marker"] = "o"
@@ -2335,10 +2345,13 @@ class Scatter:
             zorder=z_order,
             **params,
         )
-        if self._show_color_bar and self._face_color is not None and not isinstance(self.face_color, str):
+        if (
+            self._show_color_bar
+            and self._face_color is not None
+            and not isinstance(self.face_color, str)
+        ):
             fig = axes.get_figure()
             fig.colorbar(self.points_handle, ax=axes)
-
 
 
 @dataclass

--- a/graphinglib/figure.py
+++ b/graphinglib/figure.py
@@ -503,10 +503,14 @@ class Figure:
                             )
                         elif default_value == "same as scatter":
                             if isinstance(element._face_color, str):
-                                element._errorbars_color = getattr(element, "_face_color")
+                                element._errorbars_color = getattr(
+                                    element, "_face_color"
+                                )
                             else:
-                                face_color = (self._rc_dict | self._user_rc_dict)["axes.facecolor"]
-                                element._errorbars_color = self._get_contrasting_shade(face_color)
+                                face_color = plt.rcParams["axes.facecolor"]
+                                element._errorbars_color = self._get_contrasting_shade(
+                                    face_color
+                                )
                         else:
                             setattr(element, property, default_value)
                 break
@@ -521,7 +525,7 @@ class Figure:
                 file_loader = FileLoader(self._figure_style)
                 self._default_params = file_loader.load()
         return params_to_reset
-    
+
     @staticmethod
     def _get_contrasting_shade(color: str | tuple[int, int, int]) -> str:
         """
@@ -540,24 +544,24 @@ class Figure:
             Shade (black/white) that contrasts the most with the given color.
         """
         if isinstance(color, str):
-            color = to_rgba_array(color)[0,:3] * 255
+            color = to_rgba_array(color)[0, :3] * 255
 
         R, G, B = color
 
         if R <= 10:
-            Rg = R/3294
+            Rg = R / 3294
         else:
-            Rg = (R/269 + 0.0513)**2.4
+            Rg = (R / 269 + 0.0513) ** 2.4
 
         if G <= 10:
-            Gg = G/3294
+            Gg = G / 3294
         else:
-            Gg = (G/269 + 0.0513)**2.4
+            Gg = (G / 269 + 0.0513) ** 2.4
 
         if B <= 10:
-            Bg = B/3294
+            Bg = B / 3294
         else:
-            Bg = (B/269 + 0.0513)**2.4
+            Bg = (B / 269 + 0.0513) ** 2.4
 
         L = 0.2126 * Rg + 0.7152 * Gg + 0.0722 * Bg
         if L < 0.5:

--- a/unit_testing/file_manager_test.py
+++ b/unit_testing/file_manager_test.py
@@ -50,7 +50,7 @@ class TestFileUpdater(unittest.TestCase):
         filename = "a_certain_file"
         updater = FileUpdater(filename)
 
-        expected_path = f"{updater._config_dir}/{filename}.yml"
+        expected_path = f"{updater._config_dir}/custom_styles/{filename}.yml"
         self.assertEqual(updater._file_location, expected_path)
 
 


### PR DESCRIPTION
## PR summary
Closes issue #517. Fixed title of the issue, but also, the function was trying to get the default value of errorbar_color in the wrong dictionary (in the user defined rc params rather than the actual default params from the style files)

## PR checklist

- [x] Links to the related issue (#....)
- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete and documentation modified
- [x] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [x] If new files have been added, make sure they aren't excluded by .gitignore
- [x] Any new data files have been added to manifest.in
