### PR TITLE
Fixed scatter z order bug with errorbars

### DIFF
--- a/graphinglib/data_plotting_1d.py
+++ b/graphinglib/data_plotting_1d.py
@@ -2331,7 +2331,7 @@ class Scatter:
             self._x_data,
             self._y_data,
             label=self._label,
-            zorder=z_order+1,
+            zorder=z_order,
             **params,
         )
         if self._show_errorbars:
@@ -2369,7 +2369,7 @@ class Scatter:
                 self._y_data,
                 xerr=self._x_error,
                 yerr=self._y_error,
-                zorder=z_order,
+                zorder=z_order - 1,
                 **errorbar_params,
             )
 

--- a/graphinglib/figure.py
+++ b/graphinglib/figure.py
@@ -356,7 +356,7 @@ class Figure:
                         self._labels.append(element.label)
                 except AttributeError:
                     continue
-                z_order += 2
+                z_order += 5
             if not self._labels:
                 legend = False
             if legend:


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/en/latest/contributing.html#guideline-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->
Increased general z_order difference between plottabjles to 5.
Fixed z order bug with errorbars in scatter (had used z_order + 1 to raise scatters up, changed to z_order - 1 to lower the errorbars instead)

## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [x] Units tests have been run and/or modified and/or added
- [N/A] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [N/A] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/en/latest/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [N/A] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/en/latest/contributing.html#guideline-for-submitting-a-pull-request).
- [x] Links to the related issue (#....)
