### PR TITLE
Fixed bug where fill_between_color default in styles didn't do anything

### DIFF
--- a/graphinglib/data_plotting_1d.py
+++ b/graphinglib/data_plotting_1d.py
@@ -1174,8 +1174,7 @@ class Curve:
         else:
             if fill_between:
                 self._fill_between_bounds = (x1, x2)
-                if fill_color != "default":
-                    self._fill_between_color = fill_color
+                self._fill_between_color = fill_color
                 self._fill_between_other_curve = other_curve
             if np.array_equal(self._x_data, other_curve._x_data):
                 # No need to interpolate

--- a/graphinglib/default_styles/dark.yml
+++ b/graphinglib/default_styles/dark.yml
@@ -14,7 +14,7 @@ Curve:
   _error_curves_fill_between: true
   _error_curves_line_style: --
   _error_curves_line_width: 1
-  _fill_under_color: same as curve
+  _fill_between_color: same as curve
   _line_style: '-'
   _line_width: 2
 Figure:

--- a/graphinglib/default_styles/dim.yml
+++ b/graphinglib/default_styles/dim.yml
@@ -14,7 +14,7 @@ Curve:
   _error_curves_fill_between: true
   _error_curves_line_style: --
   _error_curves_line_width: 1
-  _fill_under_color: same as curve
+  _fill_between_color: same as curve
   _line_style: '-'
   _line_width: 2
 Figure:

--- a/graphinglib/default_styles/horrible.yml
+++ b/graphinglib/default_styles/horrible.yml
@@ -10,7 +10,7 @@ Curve:
   _error_curves_line_style: ':'
   _error_curves_line_width: 0.5
   _cap_thickness: "same as curve"
-  _fill_under_color: "same as curve"
+  _fill_between_color: "same as curve"
 
 Scatter:
   _face_color: "color cycle"

--- a/graphinglib/default_styles/plain.yml
+++ b/graphinglib/default_styles/plain.yml
@@ -10,7 +10,7 @@ Curve:
   _error_curves_line_style: --
   _error_curves_line_width: same as curve
   _cap_thickness: "same as curve"
-  _fill_under_color: "same as curve"
+  _fill_between_color: "same as curve"
 
 Scatter:
   _face_color: "color cycle"

--- a/graphinglib/figure.py
+++ b/graphinglib/figure.py
@@ -487,7 +487,7 @@ class Figure:
             "_errorbars_color": "_color",
             "_errorbars_line_width": "_line_width",
             "_cap_thickness": "_line_width",
-            "_fill_under_color": "_color",
+            "_fill_between_color": "_color",
             "_error_curves_line_width": "_line_width",
             "_error_curves_color": "_color",
         }


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/en/latest/contributing.html#guideline-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->
Changed name of fill_under_color to fill_between_color in style files and figure.
Bug happened because if statement ignored whenever the variable was "default" so style files were never looked up.


## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [x] Units tests have been run and/or modified and/or added
- [N/A] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [N/A] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/en/latest/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [N/A] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/en/latest/contributing.html#guideline-for-submitting-a-pull-request).
- [x] Links to the related issue (#....)
