### PR TITLE
Curve fix fill between color cycle, Scatter flexibility

### DIFF
--- a/docs/handbook/2D_plotting.rst
+++ b/docs/handbook/2D_plotting.rst
@@ -32,23 +32,25 @@ As for the :class:`~graphinglib.data_plotting_1d.Curve` and :class:`~graphinglib
 It is also possible to create a Heatmap from a list or array of values at unevenly distributed points. Take for example the data displayed below:
 
 .. plot::
-    :include-source: false
-
-    from matplotlib import pyplot as plt
 
     def func(x, y):
         return x * (1 - x) * np.cos(4 * np.pi * x) * np.sin(4 * np.pi * y**2) ** 2
 
-    rng = np.random.default_rng()
-    points = rng.random((1000, 2))
+    generator = np.random.default_rng(seed=0)
+    points = generator.random((1000, 2))
     values = func(points[:, 0], points[:, 1])
 
-    fig, ax = plt.subplots()
-    sc = ax.scatter(points[:, 0], points[:, 1], c=values, cmap="coolwarm")
-    ax.set_xlim((0, 1))
-    ax.set_ylim((0, 1))
-    fig.colorbar(sc)
-    plt.show()
+    scatter = gl.Scatter(
+        x_data=points[:, 0],
+        y_data=points[:, 1],
+        face_color=values,
+        color_map="coolwarm",
+        show_color_bar=True,
+    )
+
+    fig = gl.Figure()
+    fig.add_elements(scatter)
+    fig.show()
 
 The :py:meth:`~graphinglib.data_plotting_2d.Heatmap.from_points` method used below will interpolate the data on a grid and create a Heatmap from this interpolated data: 
  
@@ -57,8 +59,7 @@ The :py:meth:`~graphinglib.data_plotting_2d.Heatmap.from_points` method used bel
     def func(x, y):
         return x * (1 - x) * np.cos(4 * np.pi * x) * np.sin(4 * np.pi * y**2) ** 2
 
-
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(seed=0)
     points = rng.random((1000, 2))
     values = func(points[:, 0], points[:, 1])
 
@@ -71,6 +72,7 @@ The :py:meth:`~graphinglib.data_plotting_2d.Heatmap.from_points` method used bel
         grid_interpolation="cubic",
         number_of_points=(100, 100),
         origin_position="lower",
+        color_map="coolwarm",
     )
     fig.add_elements(hm)
     fig.show()

--- a/docs/handbook/scatter_fitting.rst
+++ b/docs/handbook/scatter_fitting.rst
@@ -91,6 +91,24 @@ Interpolation between data points is possible by calling the :meth:`~graphinglib
     fig.add_elements(scatter, point_at_4, *points_at_y_one_half)
     fig.show()
 
+You can also add a third dimension to your scatter plot by specifying the color of each point. This can be done by passing in a list of colors to the `face_color` or `edge_color` arguments. If you want to use a colormap, you can pass in a list of intensity values to the `face_color` or `edge_color` arguments and specify the colormap with the `color_map` argument. If you want to see the colorbar, you can set the `show_colorbar` argument to `True`.
+
+.. plot::
+
+    # Generate random x and y data
+    x = np.linspace(0, 10, 100)
+    y = np.random.rand(100) * 10
+
+    # Generate a list of intensity values which will be mapped to colors
+    z = np.sin(x) + np.cos(y) 
+
+    # Create scatter plot with color
+    scatter = gl.Scatter(x, y, face_color=z, color_map="Reds", show_color_bar=True)
+
+    fig = gl.Figure()
+    fig.add_elements(scatter)
+    fig.show()
+
 Curve fitting
 -------------
 

--- a/docs/release_notes/upcoming_changes/537.new_feature.rst
+++ b/docs/release_notes/upcoming_changes/537.new_feature.rst
@@ -1,0 +1,3 @@
+Added support for color cycles and colormaps with Scatter edge_color
+--------------------------------------------------------------------
+The `edge_color` attribute of Scatter objects now accepts a list of colors or intensities. When set to "color cycle" or if this is what the style's default is set to, the edge_color will cycle through the colors in the style's color cycle.

--- a/graphinglib/data_plotting_1d.py
+++ b/graphinglib/data_plotting_1d.py
@@ -1479,8 +1479,9 @@ class Scatter:
         Face color of the points. If an array of intensities is provided, the values are mapped to the specified color
         map. If None, marker faces are transparent.
         Default depends on the ``figure_style`` configuration.
-    edge_color : str
-        Edge color of the points.
+    edge_color : str or ArrayLike or None
+        Edge color of the points. If an array of intensities is provided, the values are mapped to the specified color
+        map. If None, marker edges are transparent.
         Default depends on the ``figure_style`` configuration.
     color_map : str or Colormap
         Color map of the stream lines, to be used in combination with the color parameter to specify intensity.
@@ -1501,9 +1502,9 @@ class Scatter:
         x_data: ArrayLike,
         y_data: ArrayLike,
         label: Optional[str] = None,
-        face_color: str | ArrayLike | NoneType | Literal["default"] = "default",
-        edge_color: str = "default",
-        color_map: str | Colormap | Literal["default"] = "default",
+        face_color: str | ArrayLike | NoneType = "default",
+        edge_color: str | ArrayLike | NoneType = "default",
+        color_map: str | Colormap = "default",
         show_color_bar: bool | Literal["default"] = "default",
         marker_size: float | Literal["default"] = "default",
         marker_style: str = "default",
@@ -1521,8 +1522,9 @@ class Scatter:
             Face color of the points. If an array of intensities is provided, the values are mapped to the specified
             color map. If None, marker faces are transparent.
             Default depends on the ``figure_style`` configuration.
-        edge_color : str
-            Edge color of the points.
+        edge_color : str or ArrayLike or None
+            Edge color of the points. If an array of intensities is provided, the values are mapped to the specified
+            color map. If None, marker edges are transparent.
             Default depends on the ``figure_style`` configuration.
         color_map : str or Colormap
             Color map of the stream lines, to be used in combination with the color parameter to specify intensity.
@@ -1562,9 +1564,9 @@ class Scatter:
         x_min: float,
         x_max: float,
         label: Optional[str] = None,
-        face_color: str | ArrayLike | NoneType | Literal["default"] = "default",
-        edge_color: str = "default",
-        color_map: str | Colormap | Literal["default"] = "default",
+        face_color: str | ArrayLike | NoneType = "default",
+        edge_color: str | ArrayLike | NoneType = "default",
+        color_map: str | Colormap = "default",
         show_color_bar: bool | Literal["default"] = "default",
         marker_size: int | Literal["default"] = "default",
         marker_style: str = "default",
@@ -1584,8 +1586,9 @@ class Scatter:
         face_color : str or ArrayLike or None
             Face color of the points. If an array of intensities is provided, the values are mapped to the specified
             color map. If None, marker faces are transparent.
-        edge_color : str
-            Edge color of the points.
+        edge_color : str or ArrayLike or None
+            Edge color of the points. If an array of intensities is provided, the values are mapped to the specified
+            color map. If None, marker edges are transparent.
             Default depends on the ``figure_style`` configuration.
         color_map : str or Colormap
             Color map of the stream lines, to be used in combination with the color parameter to specify intensity.
@@ -1940,9 +1943,9 @@ class Scatter:
         x_min: float,
         x_max: float,
         label: Optional[str] = None,
-        face_color: str | ArrayLike | Literal["default"] = "default",
-        edge_color: str = "default",
-        color_map: str | Colormap | Literal["default"] = "default",
+        face_color: str | ArrayLike | NoneType = "default",
+        edge_color: str | ArrayLike | NoneType = "default",
+        color_map: str | Colormap = "default",
         show_color_bar: bool | Literal["default"] = "default",
         marker_size: float | Literal["default"] = "default",
         marker_style: str = "default",
@@ -1957,12 +1960,13 @@ class Scatter:
             The slice will be created between x_min and x_max.
         label : str, optional
             Label to be displayed in the legend.
-        face_color : str or ArrayLike
+        face_color : str or ArrayLike or None
             Face color of the points. If an array of intensities is provided, the values are mapped to the specified
-            color map.
+            color map. If None, marker faces are transparent.
             Default depends on the ``figure_style`` configuration.
-        edge_color : str
-            Edge color of the points.
+        edge_color : str or ArrayLike or None
+            Edge color of the points. If an array of intensities is provided, the values are mapped to the specified
+            color map. If None, marker edges are transparent.
             Default depends on the ``figure_style`` configuration.
         color_map : str or Colormap
             Color map of the stream lines, to be used in combination with the color parameter to specify intensity.
@@ -2022,8 +2026,8 @@ class Scatter:
         y_min: float,
         y_max: float,
         label: Optional[str] = None,
-        face_color: str | ArrayLike | Literal["default"] = "default",
-        edge_color: str = "default",
+        face_color: str | ArrayLike | NoneType = "default",
+        edge_color: str | ArrayLike | NoneType = "default",
         color_map: str | Colormap | Literal["default"] = "default",
         show_color_bar: bool | Literal["default"] = "default",
         marker_size: float | Literal["default"] = "default",
@@ -2039,12 +2043,13 @@ class Scatter:
             The slice will be created between y_min and y_max.
         label : str, optional
             Label to be displayed in the legend.
-        face_color : str or ArrayLike
+        face_color : str or ArrayLike or None
             Face color of the points. If an array of intensities is provided, the values are mapped to the specified
-            color map.
+            color map. If None, marker faces are transparent.
             Default depends on the ``figure_style`` configuration.
-        edge_color : str
-            Edge color of the points.
+        edge_color : str or ArrayLike or None
+            Edge color of the points. If an array of intensities is provided, the values are mapped to the specified
+            color map. If None, marker edges are transparent.
             Default depends on the ``figure_style`` configuration.
         color_map : str or Colormap
             Color map of the stream lines, to be used in combination with the color parameter to specify intensity.
@@ -2408,13 +2413,11 @@ class Scatter:
         # Check whether to use color map (one of the colors is an array of intensities)
         if isinstance(self._face_color, (list, tuple, np.ndarray)):
             if all(isinstance(i, (int, float)) for i in self._face_color):
-                # Normalize intensities and convert to colors
                 color_map = plt.get_cmap(self._color_map)
                 norm = Normalize(vmin=min(self._face_color), vmax=max(self._face_color))
                 mpl_face_color = [color_map(norm(i)) for i in self._face_color]
         elif isinstance(self._edge_color, (list, tuple, np.ndarray)):
             if all(isinstance(i, (int, float)) for i in self._edge_color):
-                # Convert intensities to colors
                 color_map = plt.get_cmap(self._color_map)
                 norm = Normalize(vmin=min(self._edge_color), vmax=max(self._edge_color))
                 mpl_edge_color = [color_map(norm(i)) for i in self._edge_color]

--- a/graphinglib/data_plotting_1d.py
+++ b/graphinglib/data_plotting_1d.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from types import NoneType
 from typing import Callable, Literal, Optional, Protocol
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.colors import to_rgba, Colormap
+from matplotlib.colors import Normalize, is_color_like, to_rgba, Colormap, to_rgba_array
 from matplotlib.patches import Polygon
 from numpy.typing import ArrayLike
 from scipy.integrate import cumtrapz
@@ -657,7 +657,6 @@ class Curve:
 
     def add_error_curves(
         self,
-        x_error: Optional[ArrayLike] = None,
         y_error: Optional[ArrayLike] = None,
         error_curves_color: str = "default",
         error_curves_line_style: str = "default",
@@ -669,8 +668,6 @@ class Curve:
 
         Parameters
         ----------
-        x_error : ArrayLike, optional
-            Array of x errors.
         y_error : ArrayLike, optional
             Array of y errors.
         error_curves_color : str
@@ -681,13 +678,12 @@ class Curve:
             Default depends on the ``figure_style`` configuration.
         error_curves_line_width : float
             Line width of the error curves.
-            Default depends on the ``figure_style`` configuration.ç
+            Default depends on the ``figure_style`` configuration.
         error_curves_fill_between : bool
             Whether or not to fill the area between the two error curves.
             Default depends on the ``figure_style`` configuration.
         """
         self._show_error_curves = True
-        self._x_error = np.array(x_error) if x_error is not None else x_error
         self._y_error = np.array(y_error) if y_error is not None else y_error
         self._error_curves_color = error_curves_color
         self._error_curves_line_style = error_curves_line_style
@@ -1163,8 +1159,7 @@ class Curve:
         if other_curve is None:
             if fill_between:
                 self._fill_between_bounds = (x1, x2)
-                if fill_color != "default":
-                    self._fill_between_color = fill_color
+                self._fill_between_color = fill_color
             y_data = self._y_data
             x_data = self._x_data
             mask = (x_data >= x1) & (x_data <= x2)
@@ -1330,7 +1325,7 @@ class Curve:
             )
         return point_objects
 
-    def _plot_element(self, axes: plt.Axes, z_order: int) -> None:
+    def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs) -> None:
         """
         Plots the element in the specified axes.
         """
@@ -1339,10 +1334,22 @@ class Curve:
                 "color": self._color,
                 "linewidth": self._line_width,
                 "linestyle": self._line_style,
-                "elinewidth": self._errorbars_line_width,
+                "elinewidth": (
+                    self._errorbars_line_width
+                    if self._errorbars_line_width != "same as curve"
+                    else self._line_width
+                ),
                 "capsize": self._cap_width,
-                "capthick": self._cap_thickness,
-                "ecolor": self._errorbars_color,
+                "capthick": (
+                    self._cap_thickness
+                    if self._cap_thickness != "same as curve"
+                    else self._line_width
+                ),
+                "ecolor": (
+                    self._errorbars_color
+                    if self._errorbars_color != "same as curve"
+                    else self._color
+                ),
             }
             params = {k: v for k, v in params.items() if v != "default"}
             self.handle = axes.errorbar(
@@ -1379,35 +1386,53 @@ class Curve:
                 if self._y_error is not None
                 else self._y_data
             )
+
+            params = {
+                "color": (
+                    self._error_curves_color
+                    if self._error_curves_color != "same as curve"
+                    else self.handle[0].get_color()
+                ),
+                "linestyle": (
+                    self._error_curves_line_style
+                    if self._error_curves_line_style != "same as curve"
+                    else self._line_style
+                ),
+                "linewidth": (
+                    self._error_curves_line_width
+                    if self._error_curves_line_width != "same as curve"
+                    else self._line_width
+                ),
+            }
+
+            params = {k: v for k, v in params.items() if v != "default"}
+
             axes.plot(
                 self._x_data,
                 min_y,
-                linestyle=self._error_curves_line_style,
-                linewidth=self._error_curves_line_width,
-                color=self.handle[0].get_color(),
+                **params,
             )
             axes.plot(
                 self._x_data,
                 max_y,
-                linestyle=self._error_curves_line_style,
-                linewidth=self._error_curves_line_width,
-                color=self.handle[0].get_color(),
+                **params,
             )
             if self._error_curves_fill_between:
                 axes.fill_between(
                     self._x_data,
                     max_y,
                     min_y,
-                    color=self._error_curves_color,
+                    color=self.handle[0].get_color(),
                     alpha=0.2,
                 )
         if self._fill_between_bounds:
-            kwargs = {"alpha": 0.2}
-            if self._fill_between_color is not None:
-                kwargs["color"] = self._fill_between_color
-            else:
-                kwargs["color"] = self.handle[0].get_color()
-            kwargs = {k: v for k, v in kwargs.items() if v != "default"}
+            params = {"alpha": 0.2}
+            params["color"] = (
+                self._fill_between_color
+                if self._fill_between_color != "same as curve"
+                else self.handle[0].get_color()
+            )
+            params = {k: v for k, v in params.items() if v != "default"}
             if self._fill_between_other_curve:
                 self_y_data = self._y_data
                 self_x_data = self._x_data
@@ -1420,13 +1445,13 @@ class Curve:
                 )
                 self_y_data = interp1d(self_x_data, self_y_data)(x_data)
                 other_y_data = interp1d(other_x_data, other_y_data)(x_data)
-                kwargs["x"] = x_data
-                kwargs["y1"] = self_y_data
-                kwargs["y2"] = other_y_data
+                params["x"] = x_data
+                params["y1"] = self_y_data
+                params["y2"] = other_y_data
                 where_x_data = x_data
             else:
-                kwargs["x"] = self._x_data
-                kwargs["y1"] = self._y_data
+                params["x"] = self._x_data
+                params["y1"] = self._y_data
                 where_x_data = self._x_data
 
             axes.fill_between(
@@ -1435,7 +1460,7 @@ class Curve:
                     where_x_data <= self._fill_between_bounds[1],
                 ),
                 zorder=z_order - 2,
-                **kwargs,
+                **params,
             )
 
 
@@ -2300,10 +2325,58 @@ class Scatter:
         ]
         return points
 
-    def _plot_element(self, axes: plt.Axes, z_order: int) -> None:
+    def _get_contrasting_shade(self, color: str | tuple[int, int, int]) -> str:
+        """
+        Gives the most contrasting shade (black/white) for a given color. The algorithm used comes from this Stack
+        Exchange answer : https://ux.stackexchange.com/a/82068.
+
+        Parameters
+        ----------
+        color : str or tuple[int, int, int]
+            Color that needs to be contrasted. This can either be a known matplotlib color string or a RGB code, given
+            as a tuple of integers that take 0-255.
+
+        Returns
+        -------
+        shade : str
+            Shade (black/white) that contrasts the most with the given color.
+        """
+        if isinstance(color, str):
+            color = to_rgba_array(color)[0, :3] * 255
+
+        R, G, B = color
+
+        if R <= 10:
+            Rg = R / 3294
+        else:
+            Rg = (R / 269 + 0.0513) ** 2.4
+
+        if G <= 10:
+            Gg = G / 3294
+        else:
+            Gg = (G / 269 + 0.0513) ** 2.4
+
+        if B <= 10:
+            Bg = B / 3294
+        else:
+            Bg = (B / 269 + 0.0513) ** 2.4
+
+        L = 0.2126 * Rg + 0.7152 * Gg + 0.0722 * Bg
+        if L < 0.5:
+            return "white"
+        else:
+            return "black"
+
+    def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs) -> None:
         """
         Plots the element in the specified axes.
         """
+        # Check that either face color or edge color is not None
+        if self._face_color is None and self._edge_color is None:
+            raise ValueError(
+                "Both face color and edge color cannot be None. Please set at least one of them to a valid color."
+            )
+
         # Convert face color to matplotlib notation
         if self._face_color is None:
             # Set to transparent
@@ -2318,14 +2391,41 @@ class Scatter:
             # Use specified color
             mpl_face_color = self._face_color
 
+        # Convert edge color to matplotlib notation
+        if self._edge_color is None:
+            # Set to transparent
+            mpl_edge_color = "none"
+        elif isinstance(self._edge_color, str) and self._edge_color == "default":
+            # Use color cycle (figure uses a matplotlib style)
+            mpl_edge_color = None
+        elif isinstance(self._edge_color, str) and self._edge_color == "color cycle":
+            # Use color cycle
+            mpl_edge_color = kwargs["cycle_color"]
+        else:
+            # Use specified color
+            mpl_edge_color = self._edge_color
+
+        # Check whether to use color map (one of the colors is an array of intensities)
+        if isinstance(self._face_color, (list, tuple, np.ndarray)):
+            if all(isinstance(i, (int, float)) for i in self._face_color):
+                # Normalize intensities and convert to colors
+                color_map = plt.get_cmap(self._color_map)
+                norm = Normalize(vmin=min(self._face_color), vmax=max(self._face_color))
+                mpl_face_color = [color_map(norm(i)) for i in self._face_color]
+        elif isinstance(self._edge_color, (list, tuple, np.ndarray)):
+            if all(isinstance(i, (int, float)) for i in self._edge_color):
+                # Convert intensities to colors
+                color_map = plt.get_cmap(self._color_map)
+                norm = Normalize(vmin=min(self._edge_color), vmax=max(self._edge_color))
+                mpl_edge_color = [color_map(norm(i)) for i in self._edge_color]
+
         params = {
-            "edgecolors": self._edge_color,
             "s": self._marker_size,
             "marker": self._marker_style if self._marker_style != "default" else "o",
-            "cmap": self._color_map if not isinstance(self._face_color, str) else None,
-            "c": mpl_face_color,
         }
         params = {k: v for k, v in params.items() if v != "default"}
+        params["facecolors"] = mpl_face_color
+        params["edgecolors"] = mpl_edge_color
         self.handle = axes.scatter(
             self._x_data,
             self._y_data,
@@ -2337,14 +2437,26 @@ class Scatter:
             # Convert errorbars color to matplotlib notation
             if self._errorbars_color is None:
                 raise ValueError(
-                    "Errorbars color cannot be None. If you haven't explicitly set it to None, maybe the style you are using has set the errorbars color to mirror the Scatter face color which you have set to None. Please set the errorbars color to a valid color."
+                    "Errorbars color cannot be None. Please set the errorbars color to a valid color."
                 )
             elif isinstance(self._errorbars_color, str) and (
                 self._errorbars_color == "default"
-                or self._errorbars_color == "color cycle"
             ):
                 # Use color cycle
-                mpl_errorbars_color = self.handle.get_facecolor()
+                mpl_errorbars_color = None
+            elif (
+                isinstance(self._errorbars_color, str)
+                and self._errorbars_color == "same as scatter"
+            ):
+                marker_edge_color = self.handle.get_edgecolor()
+                marker_face_color = self.handle.get_facecolor()
+                if is_color_like(marker_edge_color):
+                    mpl_errorbars_color = marker_edge_color
+                elif is_color_like(marker_face_color):
+                    mpl_errorbars_color = marker_face_color
+                else:
+                    ax_face_color = plt.rcParams["axes.facecolor"]
+                    mpl_errorbars_color = self._get_contrasting_shade(ax_face_color)
             elif isinstance(self._errorbars_color, str):
                 # Use specified color
                 mpl_errorbars_color = self._errorbars_color
@@ -2377,8 +2489,24 @@ class Scatter:
             and self._face_color is not None
             and not isinstance(self.face_color, str)
         ):
-            fig = axes.get_figure()
-            fig.colorbar(self.handle, ax=axes)
+            # Create color bar from face color intensities
+            color_map = plt.get_cmap(self._color_map)
+            norm = Normalize(vmin=min(self._face_color), vmax=max(self._face_color))
+            sm = plt.cm.ScalarMappable(cmap=color_map, norm=norm)
+            sm.set_array([])
+            plt.colorbar(sm, ax=axes)
+
+        if (
+            self._show_color_bar
+            and self._edge_color is not None
+            and not isinstance(self.edge_color, str)
+        ):
+            # Create color bar from edge color intensities
+            color_map = plt.get_cmap(self._color_map)
+            norm = Normalize(vmin=min(self._edge_color), vmax=max(self._edge_color))
+            sm = plt.cm.ScalarMappable(cmap=color_map, norm=norm)
+            sm.set_array([])
+            plt.colorbar(sm, ax=axes)
 
 
 @dataclass
@@ -2793,7 +2921,7 @@ class Histogram:
         self._pdf_mean_color = mean_color
         self._pdf_std_color = std_color
 
-    def _plot_element(self, axes: plt.Axes, z_order: int) -> None:
+    def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs) -> None:
         """
         Plots the element in the specified axes.
         """

--- a/graphinglib/data_plotting_1d.py
+++ b/graphinglib/data_plotting_1d.py
@@ -2382,6 +2382,18 @@ class Scatter:
                 "Both face color and edge color cannot be None. Please set at least one of them to a valid color."
             )
 
+        # Check that either face color or edge color is not a list/array/tuple of intensities
+        if isinstance(self._face_color, (list, tuple, np.ndarray)) and isinstance(
+            self._edge_color, (list, tuple, np.ndarray)
+        ):
+            # If they're 3 or 4 element arrays, assume they're RGB or RGBA values
+            if len(self._face_color) in [3, 4] or len(self._edge_color) in [3, 4]:
+                pass
+            else:
+                raise ValueError(
+                    "Both face color and edge color cannot be lists/arrays/tuples of intensities or colors. Please set at least one of them to a valid color or set one of them to None."
+                )
+
         # Convert face color to matplotlib notation
         if self._face_color is None:
             # Set to transparent

--- a/graphinglib/data_plotting_2d.py
+++ b/graphinglib/data_plotting_2d.py
@@ -360,7 +360,7 @@ class Heatmap:
         """
         return deepcopy(self)
 
-    def _plot_element(self, axes: plt.Axes, z_order: int) -> None:
+    def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs) -> None:
         """
         Plots the element in the specified
         `Axes <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.html>`_.
@@ -625,7 +625,7 @@ class VectorField:
         """
         return deepcopy(self)
 
-    def _plot_element(self, axes: plt.Axes, z_order: int) -> None:
+    def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs) -> None:
         """
         Plots the element in the specified
         `Axes <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.html>`_.
@@ -870,7 +870,7 @@ class Contour:
         """
         return deepcopy(self)
 
-    def _plot_element(self, axes: plt.Axes, z_order: int) -> None:
+    def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs) -> None:
         """
         Plots the element in the specified
         `Axes <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.html>`_.
@@ -1031,7 +1031,7 @@ class Stream:
         """
         return deepcopy(self)
 
-    def _plot_element(self, axes: plt.Axes, z_order: int) -> None:
+    def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs) -> None:
         """
         Plots the element in the specified Axes.
         """

--- a/graphinglib/default_styles/dark.yml
+++ b/graphinglib/default_styles/dark.yml
@@ -115,7 +115,7 @@ Scatter:
   _cap_thickness: 2
   _cap_width: 3
   _face_color: color cycle
-  _edge_color: none
+  _edge_color:
   _color_map: RdBu
   _show_color_bar: False
   _errorbars_color: same as scatter

--- a/graphinglib/default_styles/dim.yml
+++ b/graphinglib/default_styles/dim.yml
@@ -115,7 +115,7 @@ Scatter:
   _cap_thickness: 2
   _cap_width: 3
   _face_color: color cycle
-  _edge_color: none
+  _edge_color:
   _color_map: RdBu
   _show_color_bar: False
   _errorbars_color: same as scatter

--- a/graphinglib/default_styles/horrible.yml
+++ b/graphinglib/default_styles/horrible.yml
@@ -14,7 +14,7 @@ Curve:
 
 Scatter:
   _face_color: "color cycle"
-  _edge_color: "none"
+  _edge_color:
   _color_map: "prism"
   _show_color_bar: False
   _marker_size: 4000

--- a/graphinglib/default_styles/plain.yml
+++ b/graphinglib/default_styles/plain.yml
@@ -14,7 +14,7 @@ Curve:
 
 Scatter:
   _face_color: "color cycle"
-  _edge_color: "none"
+  _edge_color:
   _color_map: "coolwarm"
   _show_color_bar: False
   _marker_size: 50

--- a/graphinglib/fits.py
+++ b/graphinglib/fits.py
@@ -238,7 +238,7 @@ class GeneralFit(Curve):
         ]
         return points
 
-    def _plot_element(self, axes: plt.Axes, z_order: int) -> None:
+    def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs) -> None:
         """
         Plots the element in the specified
         Axes

--- a/graphinglib/graph_elements.py
+++ b/graphinglib/graph_elements.py
@@ -25,7 +25,7 @@ class Plottable(Protocol):
 
     """
 
-    def _plot_element(self, axes: plt.Axes, z_order: int):
+    def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs) -> None:
         """
         Plots the element in the specified
         Axes
@@ -213,7 +213,7 @@ class Hlines:
         """
         return deepcopy(self)
 
-    def _plot_element(self, axes: plt.Axes, z_order: int) -> None:
+    def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs) -> None:
         """
         Plots the element in the specified
         Axes
@@ -427,7 +427,7 @@ class Vlines:
         """
         return deepcopy(self)
 
-    def _plot_element(self, axes: plt.Axes, z_order: int) -> None:
+    def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs) -> None:
         """
         Plots the element in the specified
         `Axes <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.html>`_.
@@ -704,7 +704,7 @@ class Point:
         """
         self._show_coordinates = True
 
-    def _plot_element(self, axes: plt.Axes, z_order: int) -> None:
+    def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs) -> None:
         """
         Plots the element in the specified
         `Axes <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.html>`_.
@@ -955,7 +955,7 @@ class Text:
         if head_length is not None:
             self._arrow_properties["headlength"] = head_length
 
-    def _plot_element(self, axes: plt.Axes, z_order: int) -> None:
+    def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs) -> None:
         """
         Plots the element in the specified Axes
         """
@@ -1218,7 +1218,7 @@ class Table:
         """
         return deepcopy(self)
 
-    def _plot_element(self, axes: plt.Axes, z_order: int) -> None:
+    def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs) -> None:
         """
         Plots the element in the specified
         `Axes <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.html>`_.

--- a/graphinglib/shapes.py
+++ b/graphinglib/shapes.py
@@ -161,7 +161,7 @@ class Arrow:
         """
         return deepcopy(self)
 
-    def _plot_element(self, axes: plt.Axes, z_order: int):
+    def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs):
         if self._two_sided:
             self._style = "<|-|>"
         else:
@@ -288,7 +288,7 @@ class Line:
         """
         return deepcopy(self)
 
-    def _plot_element(self, axes: plt.axes, z_order: int):
+    def _plot_element(self, axes: plt.axes, z_order: int, **kwargs):
         if self._capped_line:
             style = f"|-|, widthA={self._cap_width/2}, widthB={self._cap_width/2}"
         else:
@@ -740,7 +740,7 @@ class Polygon:
         else:
             raise TypeError("The other object must be a Polygon or a Curve")
 
-    def _plot_element(self, axes: plt.Axes, z_order: int):
+    def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs):
         # Create a polygon patch for the fill
         if self._fill:
             kwargs = {


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/en/latest/contributing.html#guideline-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->
Scatter now has ability to add intensity array for colour of edge or face. Also, if only edge is shown, now follows color cycle.
Fixed bug where Curve fill between didn't follow color cycle.
Closes issue #527.

## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [x] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/en/latest/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [x] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/en/latest/contributing.html#guideline-for-submitting-a-pull-request).
- [x] Links to the related issue (#....)
