### PR TITLE
546 bug scipy.interpolate.cumtrapz is deprecated

### DIFF
--- a/graphinglib/data_plotting_1d.py
+++ b/graphinglib/data_plotting_1d.py
@@ -11,7 +11,7 @@ import numpy as np
 from matplotlib.colors import Normalize, is_color_like, to_rgba, Colormap, to_rgba_array
 from matplotlib.patches import Polygon
 from numpy.typing import ArrayLike
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 from scipy.interpolate import interp1d
 
 from .graph_elements import Point
@@ -962,7 +962,9 @@ class Curve:
         A :class:`~graphinglib.data_plotting_1d.Curve` object which is the integral of the original curve.
         """
         # calculate the integral curve using cumulative trapezoidal integration
-        y_data = cumtrapz(self._y_data, self._x_data, initial=0) + initial_value
+        y_data = (
+            cumulative_trapezoid(self._y_data, self._x_data, initial=0) + initial_value
+        )
         if copy_first:
             copy = self.copy()
             copy._y_data = y_data

--- a/graphinglib/data_plotting_1d.py
+++ b/graphinglib/data_plotting_1d.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from types import NoneType
 from typing import Callable, Literal, Optional, Protocol
 
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.colors import Normalize, is_color_like, to_rgba, Colormap, to_rgba_array


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/en/latest/contributing.html#guideline-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->
Replaced scipy's interpolate.cumtrapz deprecated function by interpolate.cumulative_trapezoid
Closes issue #546.

## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [x] Units tests have been run and/or modified and/or added
- [N/A] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [N/A] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/en/latest/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [N/A] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/en/latest/contributing.html#guideline-for-submitting-a-pull-request).
- [x] Links to the related issue (#....)
