### PR TITLE
Removed axes from bottom of gallery examples

### DIFF
--- a/docs/sphinxext/gallery_generator.py
+++ b/docs/sphinxext/gallery_generator.py
@@ -143,21 +143,26 @@ Example gallery
 
 def create_thumbnail(infile, thumbfile):
     baseout, extout = op.splitext(thumbfile)
-
     im = matplotlib.image.imread(infile)
+
+    percent_keep = 0.92
     height, width, _ = im.shape
     if height <= width:
-        to_cut = (width - height) / 2
+        to_cut = (width - height * percent_keep) / 2
         if int(to_cut) != to_cut:
-            thumb = im[:, int(to_cut) : width - int(to_cut + 1), :]
+            thumb = im[
+                : int(percent_keep * height), int(to_cut) : width - int(to_cut + 1), :
+            ]
         else:
-            thumb = im[:, int(to_cut) : width - int(to_cut), :]
+            thumb = im[
+                : int(percent_keep * height), int(to_cut) : width - int(to_cut), :
+            ]
     else:
-        to_cut = (height - width) / 2
+        to_cut = (height * percent_keep - width) / 2
         if int(to_cut) != to_cut:
-            thumb = im[int(to_cut) : height - int(to_cut + 1), :, :]
+            thumb = im[int(to_cut) : int(height * percent_keep) - int(to_cut + 1), :, :]
         else:
-            thumb = im[int(to_cut) : height - int(to_cut), :, :]
+            thumb = im[int(to_cut) : int(height * percent_keep) - int(to_cut), :, :]
 
     border = int(np.ceil(0.02 * thumb.shape[0]))
     thumb[-border:, :, :3] = thumb[:border, :, :3] = np.array(


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/en/latest/contributing.html#guideline-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->
In gallery, all the bottom axes were visible in thumbnails and it made the gallery and the homepage uglier. Changed thumbnail creation cuts to zoom in a little more to cut the bottom.
Closes issue #550.

## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [N/A] Units tests have been run and/or modified and/or added
- [N/A] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [x] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/en/latest/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [N/A] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/en/latest/contributing.html#guideline-for-submitting-a-pull-request).
- [x] Links to the related issue (#....)
