### PR TITLE
Added flexibility to Point class text color

### DIFF
--- a/docs/release_notes/upcoming_changes/561.new_feature.rst
+++ b/docs/release_notes/upcoming_changes/561.new_feature.rst
@@ -1,0 +1,3 @@
+More flexibility for Point colors
+---------------------------------
+Point face and edge colors can now be set to a color or None (transparent). Text color can also be set to a color or to "same as point" (the default) to match the point color, with the edge color being prioritized over the face color if both aren't None.

--- a/graphinglib/default_styles/dark.yml
+++ b/graphinglib/default_styles/dark.yml
@@ -107,10 +107,11 @@ MultiFigure:
   - 4.8
 Point:
   _color: white
-  _edge_color: none
+  _edge_color: null
   _edge_width: 1.5
   _marker_size: 30
   _marker_style: o
+  _text_color: same as point
 Scatter:
   _cap_thickness: 2
   _cap_width: 3

--- a/graphinglib/default_styles/dim.yml
+++ b/graphinglib/default_styles/dim.yml
@@ -107,10 +107,11 @@ MultiFigure:
   - 4.8
 Point:
   _color: white
-  _edge_color: none
+  _edge_color: null
   _edge_width: 1.5
   _marker_size: 30
   _marker_style: o
+  _text_color: same as point
 Scatter:
   _cap_thickness: 2
   _cap_width: 3

--- a/graphinglib/default_styles/horrible.yml
+++ b/graphinglib/default_styles/horrible.yml
@@ -62,6 +62,7 @@ Point:
   _marker_size: 200
   _edge_width: 1.5
   _marker_style: "D"
+  _text_color: "same as point"
 
 FitFromPolynomial:
   _color: "khaki"

--- a/graphinglib/default_styles/plain.yml
+++ b/graphinglib/default_styles/plain.yml
@@ -58,10 +58,11 @@ MultiFigure:
 
 Point:
   _color: "k"
-  _edge_color: "none"
+  _edge_color: null
   _marker_size: 30
   _marker_style: "o"
   _edge_width: 1.5
+  _text_color: "same as point"
 
 FitFromPolynomial:
   _color: "k"

--- a/graphinglib/graph_elements.py
+++ b/graphinglib/graph_elements.py
@@ -495,10 +495,10 @@ class Point:
         The x and y coordinates of the :class:`~graphinglib.graph_elements.Point`.
     label : str, optional
         Label to be attached to the :class:`~graphinglib.graph_elements.Point`.
-    color : str
+    color : str or None
         Face color of the marker.
         Default depends on the ``figure_style`` configuration.
-    edge_color : str
+    edge_color : str or None
         Edge color of the marker.
         Default depends on the ``figure_style`` configuration.
     marker_size : float
@@ -515,7 +515,7 @@ class Point:
         Default depends on the ``figure_style`` configuration.
     text_color : str
         Color of the text attached to the marker.
-        Defaults to `"k"` (black).
+        "same as point" uses the color of the point (prioritize edge color, then face color). Default depends on the ``figure_style`` configuration.
     h_align, v_align : str
         Horizontal and vertical alignment of the text attached
         to the :class:`~graphinglib.graph_elements.Point`.
@@ -569,7 +569,7 @@ class Point:
             Default depends on the ``figure_style`` configuration.
         text_color : str
             Color of the text attached to the marker.
-            Default depends on the ``figure_style`` configuration.
+            "same as point" uses the color of the point (prioritize edge color, then face color). Default depends on the ``figure_style`` configuration.
         h_align, v_align : str
             Horizontal and vertical alignment of the text attached
             to the :class:`~graphinglib.graph_elements.Point`.

--- a/graphinglib/graph_elements.py
+++ b/graphinglib/graph_elements.py
@@ -527,13 +527,13 @@ class Point:
         x: float,
         y: float,
         label: Optional[str] = None,
-        color: str = "default",
-        edge_color: str = "default",
+        color: Optional[str] = "default",
+        edge_color: Optional[str] = "default",
         marker_size: float | Literal["default"] = "default",
         marker_style: str = "default",
         edge_width: float | Literal["default"] = "default",
         font_size: int | Literal["same as figure"] = "same as figure",
-        text_color: str = "k",
+        text_color: str = "default",
         h_align: str = "left",
         v_align: str = "bottom",
     ) -> None:
@@ -549,10 +549,10 @@ class Point:
             The x and y coordinates of the :class:`~graphinglib.graph_elements.Point`.
         label : str, optional
             Label to be attached to the :class:`~graphinglib.graph_elements.Point`.
-        color : str
+        color : str or None
             Face color of the marker.
             Default depends on the ``figure_style`` configuration.
-        edge_color : str
+        edge_color : str or None
             Edge color of the marker.
             Default depends on the ``figure_style`` configuration.
         marker_size : float
@@ -569,7 +569,7 @@ class Point:
             Default depends on the ``figure_style`` configuration.
         text_color : str
             Color of the text attached to the marker.
-            Defaults to ``"k"``.
+            Default depends on the ``figure_style`` configuration.
         h_align, v_align : str
             Horizontal and vertical alignment of the text attached
             to the :class:`~graphinglib.graph_elements.Point`.
@@ -619,7 +619,7 @@ class Point:
         self._label = label
 
     @property
-    def color(self) -> str:
+    def color(self) -> str | None:
         return self._color
 
     @color.setter
@@ -627,7 +627,7 @@ class Point:
         self._color = color
 
     @property
-    def edge_color(self) -> str:
+    def edge_color(self) -> str | None:
         return self._edge_color
 
     @edge_color.setter
@@ -723,6 +723,10 @@ class Point:
         Plots the element in the specified
         `Axes <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.html>`_.
         """
+        if self._color is None and self._edge_color is None:
+            raise GraphingException(
+                "Both the face color and edge color of the point can't be None. Set at least one of them."
+            )
         size = self._font_size if self._font_size != "same as figure" else None
         prefix = " " if self._h_align == "left" else ""
         postfix = " " if self._h_align == "right" else ""
@@ -731,8 +735,8 @@ class Point:
         else:
             point_label = None
         params = {
-            "c": self._color,
-            "edgecolors": self._edge_color,
+            "c": self._color if self._color is not None else "none",
+            "edgecolors": self._edge_color if self._edge_color is not None else "none",
             "s": self._marker_size,
             "marker": self._marker_style,
             "linewidths": self._edge_width,
@@ -744,8 +748,16 @@ class Point:
             zorder=z_order,
             **params,
         )
+        # get text color. if _text_color is "same as point", use the color of the point (prioritize edge color, then face color)
+        if self._text_color == "same as point":
+            if self._edge_color is not None:
+                text_color = self._edge_color
+            else:
+                text_color = self._color
+        else:
+            text_color = self._text_color
         params = {
-            "color": self._text_color,
+            "color": text_color,
             "fontsize": size,
             "horizontalalignment": self._h_align,
             "verticalalignment": self._v_align,
@@ -770,8 +782,15 @@ class Point:
                 )
             else:
                 point_label = prefix + f"({self._x:.3f}, {self._y:.3f})" + postfix
+            if self._text_color == "same as point":
+                if self._edge_color is not None:
+                    text_color = self._edge_color
+                else:
+                    text_color = self._color
+            else:
+                text_color = self._text_color
             params = {
-                "color": self._text_color,
+                "color": text_color,
                 "fontsize": size,
                 "horizontalalignment": self._h_align,
                 "verticalalignment": self._v_align,

--- a/unit_testing/graph_elements_test.py
+++ b/unit_testing/graph_elements_test.py
@@ -102,8 +102,8 @@ class TestPoint(unittest.TestCase):
     def test_font_size_is_same_as_figure(self):
         self.assertEqual(self.testPoint._font_size, "same as figure")
 
-    def test_text_color_is_k(self):
-        self.assertEqual(self.testPoint._text_color, "k")
+    def test_text_color_is_default(self):
+        self.assertEqual(self.testPoint._text_color, "default")
 
     def test_h_align_is_left(self):
         self.assertEqual(self.testPoint._h_align, "left")


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/en/latest/contributing.html#guideline-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->
Text color for Point objects is now a default with option "same as point" which prioritizes edge color, and if that's None, goes to face color. Also uses more intuitive None instead of "none" for no color.
Closes issue #560.

## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [N/A] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/en/latest/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [x] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/en/latest/contributing.html#guideline-for-submitting-a-pull-request).
- [x] Links to the related issue (#....)
