### PR TITLE
Removed s causing key error in Vlines._plot_element

### DIFF
--- a/graphinglib/graph_elements.py
+++ b/graphinglib/graph_elements.py
@@ -478,7 +478,7 @@ class Vlines:
                 }
                 params = {k: v for k, v in params.items() if v != "default"}
                 axes.axvline(self._x, zorder=z_order, **params)
-                params.pop("linewidths")
+                params.pop("linewidth")
             self.handle = VerticalLineCollection(
                 [[(0, 0)]] * (len(self._x) if len(self._x) <= 4 else 4),
                 **params,


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/en/latest/contributing.html#guideline-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->

In ``Vlines._plot_element``, a "s" was not removed after copying the line ``params.pop("linewidths")`` when the ``params`` contains ``"linewidth"`` instead.

## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [X] Units tests have been run and/or modified and/or added
- [N/A] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [N/A] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/en/latest/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [N/A] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/en/latest/contributing.html#guideline-for-submitting-a-pull-request).
- [N/A] Links to the related issue (#....)
