### PR TITLE
New ``set_grid`` method for more Figure grid customization

### DIFF
--- a/docs/release_notes/upcoming_changes/577.new_feature.rst
+++ b/docs/release_notes/upcoming_changes/577.new_feature.rst
@@ -1,0 +1,3 @@
+New ``set_grid`` method for more Figure grid customization
+----------------------------------------------------------
+Added a new ``Figure.set_grid`` method to set the grid parameters and added parameter to set which grid lines to display (either ``"both"``, ``"major"`` or ``"minor"``) independently for both axes. 

--- a/examples/curve_fill_between.py
+++ b/examples/curve_fill_between.py
@@ -39,6 +39,7 @@ area_between_curves = curve_2.get_area_between(
     fill_between=True,
 )
 
-fig = gl.Figure(size=(8, 6), x_label="x values", y_label="y values", show_grid=True)
+fig = gl.Figure(size=(8, 6), x_label="x values", y_label="y values")
+fig.set_grid()
 fig.add_elements(curve_1, curve_2)
 fig.show()

--- a/graphinglib/default_styles/dark.yml
+++ b/graphinglib/default_styles/dark.yml
@@ -183,7 +183,6 @@ Line:
 rc_params:
   axes.edgecolor: white
   axes.facecolor: black
-  axes.grid: false
   axes.labelcolor: white
   axes.linewidth: 1
   axes.prop_cycle: cycler('color', ['#3e82a0', '#edb73b', '#b9503b', '#8aba4e', '#695178',

--- a/graphinglib/default_styles/dim.yml
+++ b/graphinglib/default_styles/dim.yml
@@ -183,7 +183,6 @@ Line:
 rc_params:
   axes.edgecolor: white
   axes.facecolor: dimgrey
-  axes.grid: false
   axes.labelcolor: white
   axes.linewidth: 1
   axes.prop_cycle: cycler('color', ['#4796b8', '#edb73b', '#d04125', '#91bf5a', '#a766cc',

--- a/graphinglib/default_styles/horrible.yml
+++ b/graphinglib/default_styles/horrible.yml
@@ -229,4 +229,3 @@ rc_params:
   grid.linewidth: 5
   grid.color: "orange"
   grid.alpha: 0.3
-  axes.grid: True

--- a/graphinglib/default_styles/plain.yml
+++ b/graphinglib/default_styles/plain.yml
@@ -229,5 +229,4 @@ rc_params:
   grid.linewidth: 0.5
   grid.color: "grey"
   grid.alpha: 0.5
-  axes.grid: False
   

--- a/unit_testing/figure_test.py
+++ b/unit_testing/figure_test.py
@@ -85,8 +85,9 @@ class TestFigure(unittest.TestCase):
         self.assertListEqual(list(a_figure._size), [10, 7])
 
     def test_assign_figure_params_no_grid(self):
-        a_figure = Figure(figure_style="horrible", show_grid=False)
-        self.assertFalse(a_figure._show_grid)
+        a_figure = Figure(figure_style="plain")
+        a_figure.set_grid()
+        self.assertTrue(a_figure._show_grid)
 
     def test_element_defaults_are_reset(self):
         self.testCurve._line_width = "default"
@@ -175,38 +176,28 @@ class TestFigure(unittest.TestCase):
 
     def test_customize_visual_style(self):
         a_figure = Figure()
-        a_figure.set_visual_params(
-            figure_face_color="red", axes_face_color="blue", grid_line_style="dashed"
-        )
+        a_figure.set_visual_params(figure_face_color="red", axes_face_color="blue")
         self.assertDictEqual(
             a_figure._user_rc_dict,
             {
                 "figure.facecolor": "red",
                 "axes.facecolor": "blue",
-                "grid.linestyle": "dashed",
             },
         )
-        a_figure.set_visual_params(
-            axes_face_color="yellow", grid_line_style="dotted", x_tick_color="green"
-        )
+        a_figure.set_visual_params(axes_face_color="yellow", x_tick_color="green")
         self.assertDictEqual(
             a_figure._user_rc_dict,
             {
                 "figure.facecolor": "red",
                 "axes.facecolor": "yellow",
-                "grid.linestyle": "dotted",
                 "xtick.color": "green",
             },
         )
 
     def test_customize_visual_style_reset(self):
         a_figure = Figure()
-        a_figure.set_visual_params(
-            figure_face_color="red", axes_face_color="blue", grid_line_style="dashed"
-        )
-        a_figure.set_visual_params(
-            axes_face_color="yellow", grid_line_style="dotted", x_tick_color="green"
-        )
+        a_figure.set_visual_params(figure_face_color="red", axes_face_color="blue")
+        a_figure.set_visual_params(axes_face_color="yellow", x_tick_color="green")
         a_figure.set_visual_params(reset=True)
         self.assertDictEqual(a_figure._user_rc_dict, {})
 


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->

Added a new ``Figure.set_grid`` method to set the grid parameters and added parameter to set which grid lines to display (either ``"both"``, ``"major"`` or ``"minor"``) independently for both axes. 

## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [X] Units tests have been run and/or modified and/or added
- [X] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [x] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/latest/contributing/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [X] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request).
- [N/A] Links to the related issue (#....)
