### PR TITLE
Parameter ``y`` in Vlines can be int or float as ``x`` in Hlines

### DIFF
--- a/graphinglib/graph_elements.py
+++ b/graphinglib/graph_elements.py
@@ -258,10 +258,7 @@ class Hlines:
                 axes.axhline(self._y, zorder=z_order, **params)
                 params.pop("linewidth")
             if isinstance(self._y, (int, float)):
-                self.handle = LineCollection(
-                    [[(0, 0)]] * 1,
-                    **params,
-                )
+                self.handle = LineCollection([[(0, 0)]] * 1, **params)
             else:
                 self.handle = LineCollection(
                     [[(0, 0)]] * (len(self._y) if len(self._y) <= 3 else 3),
@@ -479,14 +476,13 @@ class Vlines:
                 params = {k: v for k, v in params.items() if v != "default"}
                 axes.axvline(self._x, zorder=z_order, **params)
                 params.pop("linewidth")
-            self.handle = VerticalLineCollection(
-                [[(0, 0)]] * (len(self._x) if len(self._x) <= 4 else 4),
-                **params,
-            )
-            self.handle = VerticalLineCollection(
-                [[(0, 0)]] * (len(self._x) if len(self._x) <= 4 else 4),
-                **params,
-            )
+            if isinstance(self._x, (int, float)):
+                self.handle = VerticalLineCollection([[(0, 0)]] * 1, **params)
+            else:
+                self.handle = VerticalLineCollection(
+                    [[(0, 0)]] * (len(self._x) if len(self._x) <= 4 else 4),
+                    **params,
+                )
 
 
 class Point:


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->

Corrected bug in Vlines making it not possible to set an int or float as ``y`` when it is possible for ``x`` in Hlines. Closes #575 

## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [X] Units tests have been run and/or modified and/or added
- [X] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [N/A] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/latest/contributing/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [N/A] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request).
- [X] Links to the related issue (#....)
