### PR TITLE
Nans are now ignored in to_desmos method

### DIFF
--- a/docs/release_notes/upcoming_changes/607.bugfix.rst
+++ b/docs/release_notes/upcoming_changes/607.bugfix.rst
@@ -1,0 +1,3 @@
+NaNs are now ignored in to_desmos
+---------------------------------
+Not a number values (NaNs) are now ignored when calling the `to_desmos` method of `Plottable1D` objects.

--- a/graphinglib/data_plotting_1d.py
+++ b/graphinglib/data_plotting_1d.py
@@ -58,6 +58,9 @@ class Plottable1D:
         Gives the data points in a Desmos-readable format. The outputted string can then be pasted into a single Desmos
         cell and the object's data will be displayed.
 
+        .. note::
+            NaN values are ignored.
+
         Parameters
         ----------
         x_data, y_data : ArrayLike

--- a/graphinglib/data_plotting_1d.py
+++ b/graphinglib/data_plotting_1d.py
@@ -85,6 +85,8 @@ class Plottable1D:
 
         formatted_points = "["
         for x, y in zip(sorted_x_data, sorted_y_data):
+            if np.isnan(x) or np.isnan(y):
+                continue
             x_num, x_exponent = f"{x:.{decimal_precision:d}e}".split("e")
             y_num, y_exponent = f"{y:.{decimal_precision:d}e}".split("e")
             formatted_points += f"({format_tex(x_num, x_exponent)},{format_tex(y_num, y_exponent)}),"


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->
Fixed a bug where having nan values in a `Plottable1D` and calling the `to_desmos` method would raise a `ValueError`. Nans are now ignored.


## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete
- [x] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [x] If new files have been added, make sure they aren't excluded by .gitignore
- [x] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/latest/contributing/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [x] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request).
- [N/A] Links to the related issue (#....)
