### PR TITLE
Refactor copy_with into shared helper

### DIFF
--- a/docs/release_notes/upcoming_changes/637.improvement.rst
+++ b/docs/release_notes/upcoming_changes/637.improvement.rst
@@ -1,0 +1,3 @@
+Improved `copy_with` support
+----------------------------
+Added `copy_with` to all objects, and improved validation so only public writable properties can be overridden.

--- a/graphinglib/figure.py
+++ b/graphinglib/figure.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from shutil import which
 from typing import Literal, Optional
 from warnings import warn
@@ -16,6 +17,12 @@ from .legend_artists import (
     VerticalLineCollection,
     histogram_legend_artist,
 )
+from .tools import _copy_with_overrides
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class Figure:
@@ -229,6 +236,29 @@ class Figure:
         """
         for element in elements:
             self._elements.append(element)
+
+    def copy(self) -> Self:
+        """
+        Returns a deep copy of the :class:`~graphinglib.figure.Figure` object.
+        """
+        return deepcopy(self)
+
+    def copy_with(self, **kwargs) -> Self:
+        """
+        Returns a deep copy of the Figure with specified attributes overridden.
+
+        Parameters
+        ----------
+        **kwargs
+            Public writable properties to override in the copied Figure. The keys should be property names to modify
+            and the values are the new values for those properties.
+
+        Returns
+        -------
+        Figure
+            A new Figure instance with the specified attributes overridden.
+        """
+        return _copy_with_overrides(self, **kwargs)
 
     def _prepare_figure(
         self,
@@ -1027,6 +1057,29 @@ class TwinAxis:
         """
         for element in elements:
             self._elements.append(element)
+
+    def copy(self) -> Self:
+        """
+        Returns a deep copy of the :class:`~graphinglib.figure.TwinAxis` object.
+        """
+        return deepcopy(self)
+
+    def copy_with(self, **kwargs) -> Self:
+        """
+        Returns a deep copy of the TwinAxis with specified attributes overridden.
+
+        Parameters
+        ----------
+        **kwargs
+            Public writable properties to override in the copied TwinAxis. The keys should be property names to modify
+            and the values are the new values for those properties.
+
+        Returns
+        -------
+        TwinAxis
+            A new TwinAxis instance with the specified attributes overridden.
+        """
+        return _copy_with_overrides(self, **kwargs)
 
     def set_visual_params(
         self,

--- a/graphinglib/graph_elements.py
+++ b/graphinglib/graph_elements.py
@@ -18,6 +18,7 @@ try:
 except ImportError:
     from typing_extensions import Self
 
+
 @runtime_checkable
 class Plottable(Protocol):
     """

--- a/graphinglib/graph_elements.py
+++ b/graphinglib/graph_elements.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass, field
-from difflib import get_close_matches
 from typing import Literal, Optional, Protocol, runtime_checkable
 
 import matplotlib.pyplot as plt
@@ -12,12 +11,12 @@ from matplotlib.figure import Figure as MPLFigure
 from numpy.typing import ArrayLike
 
 from .legend_artists import VerticalLineCollection
+from .tools import _copy_with_overrides
 
 try:
     from typing import Self
 except ImportError:
     from typing_extensions import Self
-
 
 @runtime_checkable
 class Plottable(Protocol):
@@ -37,8 +36,8 @@ class Plottable(Protocol):
         Parameters
         ----------
         **kwargs
-            Properties to override in the copied Plottable. The keys should be property names to modify and the values
-            are the new values for those properties.
+            Public writable properties to override in the copied Plottable. The keys should be property names to
+            modify and the values are the new values for those properties.
 
         Returns
         -------
@@ -52,31 +51,7 @@ class Plottable(Protocol):
             curve = Curve(x_data, y_data, color='blue')
             new_curve = curve.copy_with(color='red', line_style='dashed')
         """
-        properties = [
-            attr
-            for attr in dir(self.__class__)
-            if isinstance(getattr(self.__class__, attr, None), property)
-        ]
-        properties = list(
-            filter(lambda x: x[0] != "_", properties)
-        )  # filter out hidden properties
-        print(properties)
-        new_copy = deepcopy(self)
-        for key, value in kwargs.items():
-            if hasattr(new_copy, key):
-                setattr(new_copy, key, value)
-            else:
-                close_match = get_close_matches(key, properties, n=1, cutoff=0.6)
-                if close_match:
-                    raise AttributeError(
-                        f"{self.__class__.__name__} has no attribute '{key}'. "
-                        f"Did you mean '{close_match[0]}'?"
-                    )
-                else:
-                    raise AttributeError(
-                        f"{self.__class__.__name__} has no attribute '{key}'."
-                    )
-        return new_copy
+        return _copy_with_overrides(self, **kwargs)
 
     def __deepcopy__(self, memo: dict) -> Self:
         """

--- a/graphinglib/multifigure.py
+++ b/graphinglib/multifigure.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from shutil import which
 from string import ascii_lowercase
 from typing import Literal, Optional
@@ -19,6 +20,7 @@ from .legend_artists import (
     VerticalLineCollection,
     histogram_legend_artist,
 )
+from .tools import _copy_with_overrides
 
 try:
     from typing import Self
@@ -172,6 +174,29 @@ class MultiFigure:
     @size.setter
     def size(self, size: tuple[float, float] | Literal["default"]) -> None:
         self._size = size
+
+    def copy(self) -> Self:
+        """
+        Returns a deep copy of the :class:`~graphinglib.multifigure.MultiFigure` object.
+        """
+        return deepcopy(self)
+
+    def copy_with(self, **kwargs) -> Self:
+        """
+        Returns a deep copy of the MultiFigure with specified attributes overridden.
+
+        Parameters
+        ----------
+        **kwargs
+            Public writable properties to override in the copied MultiFigure. The keys should be property names to
+            modify and the values are the new values for those properties.
+
+        Returns
+        -------
+        MultiFigure
+            A new MultiFigure instance with the specified attributes overridden.
+        """
+        return _copy_with_overrides(self, **kwargs)
 
     @classmethod
     def from_row(

--- a/graphinglib/smart_figure.py
+++ b/graphinglib/smart_figure.py
@@ -2,7 +2,6 @@ from __future__ import annotations as _annotations_
 
 from collections import OrderedDict
 from copy import deepcopy
-from difflib import get_close_matches
 from logging import warning
 from shutil import which
 from string import ascii_lowercase
@@ -39,6 +38,7 @@ from .legend_artists import (
     VerticalLineCollection,
     histogram_legend_artist,
 )
+from .tools import _copy_with_overrides
 
 T = TypeVar("T")
 ListOrItem = Union[T, list[T]]
@@ -1156,8 +1156,8 @@ class SmartFigure:
         Parameters
         ----------
         **kwargs
-            Properties to override in the copied SmartFigure. The keys should be property names to modify and the values
-            are the new values for those properties.
+            Public writable properties to override in the copied SmartFigure. The keys should be property names to
+            modify and the values are the new values for those properties.
 
         Returns
         -------
@@ -1170,30 +1170,7 @@ class SmartFigure:
 
             fig2 = fig1.copy_with(x_label=None, y_label=None)
         """
-        properties = [
-            attr
-            for attr in dir(self.__class__)
-            if isinstance(getattr(self.__class__, attr, None), property)
-        ]
-        properties = list(
-            filter(lambda x: x[0] != "_", properties)
-        )  # filter out hidden properties
-        new_copy = deepcopy(self)
-        for key, value in kwargs.items():
-            if hasattr(new_copy, key):
-                setattr(new_copy, key, value)
-            else:
-                close_match = get_close_matches(key, properties, n=1, cutoff=0.6)
-                if close_match:
-                    raise AttributeError(
-                        f"{self.__class__.__name__} has no attribute '{key}'. "
-                        f"Did you mean '{close_match[0]}'?"
-                    )
-                else:
-                    raise AttributeError(
-                        f"{self.__class__.__name__} has no attribute '{key}'."
-                    )
-        return new_copy
+        return _copy_with_overrides(self, **kwargs)
 
     @property
     def _ordered_elements(self) -> OrderedDict:
@@ -4030,9 +4007,9 @@ class SmartTwinAxis:
 
         Parameters
         ----------
-        kwargs
-            Properties to override in the copied SmartTwinAxis. The keys should be property names to modify and the
-            values are the new values for those properties.
+        **kwargs
+            Public writable properties to override in the copied SmartTwinAxis. The keys should be property names to
+            modify and the values are the new values for those properties.
 
         Returns
         -------
@@ -4045,30 +4022,7 @@ class SmartTwinAxis:
 
             twin_ax_2 = twin_ax_1.copy_with(label="New Label")
         """
-        properties = [
-            attr
-            for attr in dir(self.__class__)
-            if isinstance(getattr(self.__class__, attr, None), property)
-        ]
-        properties = list(
-            filter(lambda x: x[0] != "_", properties)
-        )  # filter out hidden properties
-        new_copy = deepcopy(self)
-        for key, value in kwargs.items():
-            if hasattr(new_copy, key):
-                setattr(new_copy, key, value)
-            else:
-                close_match = get_close_matches(key, properties, n=1, cutoff=0.6)
-                if close_match:
-                    raise AttributeError(
-                        f"{self.__class__.__name__} has no attribute '{key}'. "
-                        f"Did you mean '{close_match[0]}'?"
-                    )
-                else:
-                    raise AttributeError(
-                        f"{self.__class__.__name__} has no attribute '{key}'."
-                    )
-        return new_copy
+        return _copy_with_overrides(self, **kwargs)
 
     def add_elements(self, *elements: Plottable | None) -> Self:
         """

--- a/unit_testing/figure_test.py
+++ b/unit_testing/figure_test.py
@@ -39,6 +39,24 @@ class TestFigure(unittest.TestCase):
         self.testFigure.add_elements(other_curve, other_other_curve)
         self.assertTrue(len(self.testFigure._elements), 3)
 
+    def test_copy_and_copy_with(self):
+        copied = self.testFigure.copy()
+        self.assertIsNot(copied, self.testFigure)
+
+        modified = self.testFigure.copy_with(title="New Title")
+        self.assertEqual(modified.title, "New Title")
+        self.assertEqual(self.testFigure.title, None)
+
+    def test_copy_with_suggests_similar_property(self):
+        with self.assertRaisesRegex(AttributeError, "Did you mean 'title'"):
+            self.testFigure.copy_with(titel="New Title")
+
+    def test_copy_with_rejects_private_property(self):
+        with self.assertRaisesRegex(
+            AttributeError, "has no public writable property '_title'"
+        ):
+            self.testFigure.copy_with(_title="New Title")
+
     def test_all_curves_plotted(self):
         self.testFigure.add_elements(self.testCurve)
         self.testFigure._prepare_figure()
@@ -256,6 +274,20 @@ class TestTwinAxis(unittest.TestCase):
         curve = Curve([1, 2, 3], [1, 2, 3])
         twin.add_elements(curve)
         self.assertEqual(twin._elements[0], curve)
+
+    def test_copy_and_copy_with(self):
+        twin = TwinAxis(label="A", log_scale=False)
+        copied = twin.copy()
+        self.assertIsNot(copied, twin)
+
+        modified = twin.copy_with(label="B")
+        self.assertEqual(modified.label, "B")
+        self.assertEqual(twin.label, "A")
+
+    def test_copy_with_rejects_read_only_property(self):
+        twin = TwinAxis()
+        with self.assertRaisesRegex(AttributeError, "read-only property"):
+            twin.copy_with(axis_lim=(0, 1))
 
     def test_customized_visual_style(self):
         twin = TwinAxis()

--- a/unit_testing/graph_elements_test.py
+++ b/unit_testing/graph_elements_test.py
@@ -48,6 +48,26 @@ class TestHlines(unittest.TestCase):
         self.assertEqual(testHlinesCopy._line_styles, self.testHlines._line_styles)
         self.assertEqual(testHlinesCopy._alpha, self.testHlines._alpha)
 
+    def test_copy_with(self):
+        copied = self.testHlines.copy_with(colors="red")
+        self.assertIsNot(copied, self.testHlines)
+        self.assertEqual(copied.colors, "red")
+        self.assertEqual(self.testHlines.colors, "default")
+
+    def test_copy_with_rejects_private_property(self):
+        with self.assertRaisesRegex(
+            AttributeError, "has no public writable property '_y'"
+        ):
+            self.testHlines.copy_with(_y=[2, 3, 4])
+
+    def test_copy_with_suggests_similar_property(self):
+        with self.assertRaisesRegex(AttributeError, "Did you mean 'colors'"):
+            self.testHlines.copy_with(colrs="red")
+
+    def test_copy_with_rejects_read_only_property(self):
+        with self.assertRaisesRegex(AttributeError, "read-only property"):
+            self.testHlines.copy_with(alpha=0.5)
+
     def test_single_line_accepts_single_item_style_lists(self):
         style_kwargs = [
             {"colors": ["r"]},

--- a/unit_testing/multifigure_test.py
+++ b/unit_testing/multifigure_test.py
@@ -32,6 +32,25 @@ class TestMultiFigure(unittest.TestCase):
         self.assertDictEqual(another_multifig._rc_dict, {})
         self.assertDictEqual(another_multifig._user_rc_dict, {})
 
+    def test_copy_and_copy_with(self):
+        a_multifig = MultiFigure(num_rows=2, num_cols=2, title="Original")
+        copied = a_multifig.copy()
+        self.assertIsNot(copied, a_multifig)
+
+        modified = a_multifig.copy_with(title="Modified")
+        self.assertEqual(modified.title, "Modified")
+        self.assertEqual(a_multifig.title, "Original")
+
+    def test_copy_with_suggests_similar_property(self):
+        a_multifig = MultiFigure(num_rows=2, num_cols=2, title="Original")
+        with self.assertRaisesRegex(AttributeError, "Did you mean 'title'"):
+            a_multifig.copy_with(titel="Modified")
+
+    def test_copy_with_rejects_read_only_property(self):
+        a_multifig = MultiFigure(num_rows=2, num_cols=2, title="Original")
+        with self.assertRaisesRegex(AttributeError, "read-only property"):
+            a_multifig.copy_with(num_rows=3)
+
     def test_create_multifigure_raises(self):
         # Test that raises error if num_rows or num_cols is not an integer or is less than 1
         with self.assertRaises(TypeError):


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->

Closes #599. Introduces a shared helper for copy_with and standardizes it across GraphingLib objects.

- Introduced graphinglib.tools._copy_with_overrides(instance, **kwargs).
- Updated existing implementations (Plottable, SmartFigure, SmartTwinAxis) to use the shared helper.
- Added copy() and copy_with(**kwargs) to Figure, TwinAxis, and MultiFigure.
- Rejects private/internal names,  read-only properties, method names
- Suggests close property names on typos 

## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [N/A] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/latest/contributing/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [ ] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request).
- [x] Links to the related issue (#....)
