### PR TITLE
Fixed bug where "subtitles" weren't padded

### DIFF
--- a/graphinglib/smart_figure.py
+++ b/graphinglib/smart_figure.py
@@ -1781,7 +1781,7 @@ class SmartFigure:
                     pad = (
                         subtitles_pad[subplot_i] if subtitles_pad is not None else None
                     )
-                    ax.set_title(self._subtitles[subplot_i], pad=pad)
+                    ax.set_title(self._subplot_p["subtitles"][subplot_i], pad=pad)
 
                 # Axes sub_labels
                 self._customize_ax_label(ax, subplot_i)

--- a/unit_testing/smart_figure_test.py
+++ b/unit_testing/smart_figure_test.py
@@ -831,11 +831,21 @@ class TestSmartFigure(unittest.TestCase):
                 ["T 1", None, "T 2", None, "T 3"],
             ],
         }
+        self.fig_2x3.set_grid()
         for param, values in params.items():
             fig = self.fig_2x3.copy_with(**{param: values[0]})  # underfilled list
             fig._fill_per_subplot_params()
+            fig._figure = plt.figure()
+            fig._reference_label_i = 0
+            fig._prepare_figure()
+            plt.close()
+
             fig = self.fig_2x3.copy_with(**{param: values[1]})  # equally filled list
             fig._fill_per_subplot_params()
+            fig._figure = plt.figure()
+            fig._reference_label_i = 0
+            fig._prepare_figure()
+            plt.close()
             with self.assertRaises(GraphingException):
                 fig = self.fig_2x3.copy_with(**{param: values[2]})  # overfilled list
                 fig._fill_per_subplot_params()
@@ -877,7 +887,9 @@ class TestSmartFigure(unittest.TestCase):
 
         for param, values in params.items():
             fig = self.fig_2x2.copy_with(**{param: values})
+            fig._fill_per_subplot_params()
             fig._figure = plt.figure()
+            fig._reference_label_i = 0
             with self.assertRaises(GraphingException):
                 fig._prepare_figure()
             plt.close(self.fig._figure)


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->
Fixed a bug in the `SmartFigure` where the wrong list was used to add `subtitles` to subplots, which caused errors in the case where the list was shorter than the length of the `SmartFigure`. Also updated the unit tests to check for these kind of errors with other `ListOrItem` properties.

No release note was created since the `SmartFigure` hasn't been implemented in an official version yet.


## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [x] Units tests have been run and/or modified and/or added
- [N/A] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [N/A] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/latest/contributing/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [N/A] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request).
- [N/A] Links to the related issue (#....)
