### PR TITLE
Fixed "default" params not replaced in `Shapes`' `_plot_element` method

### DIFF
--- a/docs/release_notes/upcoming_changes/652.bugfix.rst
+++ b/docs/release_notes/upcoming_changes/652.bugfix.rst
@@ -1,0 +1,3 @@
+Bugfix for `Shapes` in matplotlib styles
+----------------------------------------
+Fixed a bug where the `Shapes` class was not replacing its `"default"` values when plotting, which caused errors when using matplotlib styles that have default values for these parameters..

--- a/graphinglib/shapes.py
+++ b/graphinglib/shapes.py
@@ -233,29 +233,36 @@ class Arrow(Plottable):
                     )
         else:
             style = self._style
-        head_length, head_width = self._head_size * 0.4, self._head_size * 0.2
 
-        # Set specific arrow properties
-        match self._style:
-            case "->" | "-|>" | "simple" | "fancy":
-                prop_style_values = (
-                    f"head_width={head_width}, head_length={head_length}"
-                )
-            case "-[":
-                prop_style_values = f"widthB={head_width}" + (
-                    f", widthA={head_width}" if self._two_sided else ""
-                )
-            case "]->":
-                prop_style_values = f"widthA={head_width}"
-            case "wedge":
-                prop_style_values = f"tail_width={head_width}"
+        if self._head_size != "default":
+            head_length, head_width = self._head_size * 0.4, self._head_size * 0.2
+
+            # Set specific arrow properties
+            match self._style:
+                case "->" | "-|>" | "simple" | "fancy":
+                    prop_style_values = (
+                        f"head_width={head_width}, head_length={head_length}"
+                    )
+                case "-[":
+                    prop_style_values = f"widthB={head_width}" + (
+                        f", widthA={head_width}" if self._two_sided else ""
+                    )
+                case "]->":
+                    prop_style_values = f"widthA={head_width}"
+                case "wedge":
+                    prop_style_values = f"tail_width={head_width}"
+
+            arrow_style = f"{style}, {prop_style_values}"
+        else:
+            arrow_style = style
 
         props = {
-            "arrowstyle": f"{style}, {prop_style_values}",
+            "arrowstyle": arrow_style,
             "color": self._color,
             "linewidth": self._width,
             "alpha": self._alpha,
         }
+        props = {k: v for k, v in props.items() if v != "default"}
         if self._shrink != 0:
             shrinkPointA, shrinkPointB = self._shrink_points()
             axes.annotate(
@@ -401,6 +408,7 @@ class Line(Plottable):
             "linewidth": self._width,
             "alpha": self._alpha,
         }
+        props = {k: v for k, v in props.items() if v != "default"}
         axes.annotate(
             "",
             self._pointA,
@@ -846,24 +854,26 @@ class Polygon(Plottable):
     def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs):
         # Create a polygon patch for the fill
         if self._fill:
-            kwargs = {
+            params = {
                 "alpha": self._fill_alpha,
                 "zorder": z_order,
             }
             if self._fill_color is not None:
-                kwargs["facecolor"] = self._fill_color
-            polygon_fill = MPLPolygon(self.vertices, **kwargs)
+                params["facecolor"] = self._fill_color
+            params = {k: v for k, v in params.items() if v != "default"}
+            polygon_fill = MPLPolygon(self.vertices, **params)
             axes.add_patch(polygon_fill)
         # Create a polygon patch for the edge
         if self._edge_color is not None:
-            kwargs = {
+            params = {
                 "fill": None,
                 "linewidth": self._line_width,
                 "linestyle": self._line_style,
                 "edgecolor": self._edge_color,
                 "zorder": z_order,
             }
-            polygon_edge = MPLPolygon(self.vertices, **kwargs)
+            params = {k: v for k, v in params.items() if v != "default"}
+            polygon_edge = MPLPolygon(self.vertices, **params)
             axes.add_patch(polygon_edge)
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->
Fixed bugs where `Shapes` could not be plotted with `"default"` values when using matplotlib styles. This PR mainly adds the line:
```
params = {k: v for k, v in params.items() if v != "default"}
```
to `Polygon`/`Arrow`/`Line._plot_element` methods and also adds checks for `Arrow._head_size` which are necessary if a matplotlib style is used.


## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [x] Units tests have been run and/or modified and/or added
- [N/A] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [N/A] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/latest/contributing/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [x] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request).
- [N/A] Links to the related issue (#....)
