### PR TITLE
added label+handle for PlottableAxMethod

### DIFF
--- a/graphinglib/graph_elements.py
+++ b/graphinglib/graph_elements.py
@@ -1626,13 +1626,15 @@ class PlottableAxMethod(Plottable):
         `Axes <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.html>`_.
         """
         try:
-            self.handle = getattr(axes, self.meth)(
-                *self.args, zorder=z_order, **self.kwargs
-            )[0]
+            attrs = getattr(axes, self.meth)(*self.args, zorder=z_order, **self.kwargs)
+            if isinstance(attrs, list) and len(attrs) > 0:
+                self.handle = attrs[0]
         except TypeError as e:
             if "zorder" in str(e):
                 try:
-                    self.handle = getattr(axes, self.meth)(*self.args, **self.kwargs)[0]
+                    attrs = getattr(axes, self.meth)(*self.args, **self.kwargs)
+                    if isinstance(attrs, list) and len(attrs) > 0:
+                        self.handle = attrs[0]
                 except Exception as e2:
                     raise GraphingException(
                         f"Failed to call Axes method '{self.meth}' with provided arguments. Please check that all "

--- a/graphinglib/graph_elements.py
+++ b/graphinglib/graph_elements.py
@@ -1607,14 +1607,18 @@ class PlottableAxMethod(Plottable):
             class. If not, an exception will be raised when attempting to plot the element.
     *args
         Positional arguments to pass to ``axes.meth``.
+    label : str, optional
+        Label to be attached to the :class:`~graphinglib.graph_elements.PlottableAxMethod`.
     **kwargs
         Keyword arguments to pass to ``axes.meth``.
     """
 
-    def __init__(self, meth: str, *args, **kwargs) -> None:
+    def __init__(self, meth: str, *args, label: Optional[str] = None, **kwargs) -> None:
         self.meth = meth
         self.args = args
         self.kwargs = kwargs
+        self.label = label
+        self.handle = None
 
     def _plot_element(self, axes: plt.Axes, z_order: int, **kwargs) -> None:
         """
@@ -1622,11 +1626,13 @@ class PlottableAxMethod(Plottable):
         `Axes <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.html>`_.
         """
         try:
-            getattr(axes, self.meth)(*self.args, zorder=z_order, **self.kwargs)
+            self.handle = getattr(axes, self.meth)(
+                *self.args, zorder=z_order, **self.kwargs
+            )[0]
         except TypeError as e:
             if "zorder" in str(e):
                 try:
-                    getattr(axes, self.meth)(*self.args, **self.kwargs)
+                    self.handle = getattr(axes, self.meth)(*self.args, **self.kwargs)[0]
                 except Exception as e2:
                     raise GraphingException(
                         f"Failed to call Axes method '{self.meth}' with provided arguments. Please check that all "


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->

Fixed a bug where `PlottableAxMethod` objects would not show in the legend. This was caused by the `PlottableAxMethod` not having `label` and `handle` arguments. 
Edit: Only getting the handle if it exists. This should make it so it cannot cause errors for any ax method that doesn't generate a legend handle.

## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [X] Units tests have been run and/or modified and/or added
- [X] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [X] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/latest/contributing/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [N/A] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request).
- [N/A] Links to the related issue (#....)
