### PR TITLE
Implemented clicking behaviour for `SmartFigure` objects

### DIFF
--- a/docs/handbook/smart_figure_advanced.rst
+++ b/docs/handbook/smart_figure_advanced.rst
@@ -174,13 +174,13 @@ To remove elements, set them to ``None``:
     # Remove element from specific subplot
     fig[0, 1] = None
 
-    # Remove element spanning multiple subplots (must use exact slice used to add it)
-    fig[1, :] = None    # Remove it (using same slice)
+    # Remove multi-cell element - can use any cell it occupies
+    fig[1, 0] = None    # Removes the entire [1, :] element
 
     fig.show()
 
-.. warning::
-   To remove a spanning element, you **must** use the exact slice that was used to add it. Using ``fig[0, :] = None`` will not remove single-subplot elements added in the first row.
+.. note::
+   When a multi-cell element is removed, you can delete it by clicking on **any** cell it occupies. For example, if an element spans ``[1, :]`` (the entire second row), you can remove it with ``fig[1, 0] = None``, ``fig[1, 1] = None``, or ``fig[1, :] = None``.
 
 Retrieving Elements
 -------------------
@@ -210,6 +210,84 @@ You can also iterate on the :class:`~graphinglib.SmartFigure` directly to access
         subplot[1].line_width = line_width  # Modify the second element
 
     fig.show()
+
+
+Accessing Multi-Cell Elements
+------------------------------
+
+One of the most powerful features of :class:`~graphinglib.SmartFigure` is the ability to access and modify elements that span multiple cells by clicking on **any** cell they occupy:
+
+.. plot::
+    :context: close-figs
+
+    # Create a figure with a multi-cell element spanning the entire first row
+    fig = gl.SmartFigure(2, 3)
+    fig[0, :] = curve1  # Spans all three columns of row 0
+    fig.show()
+
+    # You can access this element via any cell it occupies
+    element_via_col0 = fig[0, 0]  # Access via first column
+    element_via_col1 = fig[0, 1]  # Access via second column
+    element_via_col2 = fig[0, 2]  # Access via third column
+    element_via_slice1 = fig[0, 1:]  # Access via inexact slice
+    element_via_slice2 = fig[0, :]  # Access via exact slice
+
+This makes it much more intuitive to work with complex layouts:
+
+.. plot::
+    :context: close-figs
+
+    fig = gl.SmartFigure(3, 2)
+
+    # Add elements with different spans
+    fig[0, :] = curve1     # Top row, spans both columns
+    fig[1, 0] = curve2     # Middle left, single cell
+    fig[1, 1] = [curve1, curve2]  # Middle right, single cell with multiple elements
+    fig[2, :] = gl.Histogram(np.random.randn(1000), bins=30)  # Bottom row, spans both columns
+
+    # Access and modify via clicking on any cell
+    fig[0, 0][0].color = "red"  # Modify top row element via first column
+    fig[2, 1][0].face_color = "green"  # Modify bottom histogram via second column
+
+    fig.show()
+
+.. warning::
+    The only rule that needs to be followed is that you cannot access or modify elements using a slice that overlaps with multiple **different** subplots. Therefore, you must always use a slice that includes at most a single non-empty subplot.
+
+.. plot::
+    :context: close-figs
+
+    fig = gl.SmartFigure(2, 2)
+    fig[0, :] = curve1  # Spans entire first row
+    fig[1, 0] = curve2  # Single cell in second row
+    fig.show()
+
+    # This raises an error - slice overlaps with two different elements
+    try:
+        element = fig[0:2, :]
+    except gl.GraphingException:
+        print("Cannot access multiple different elements with one slice")
+
+When you replace a multi-cell element, the new element will inherit the span of the original element:
+
+.. plot::
+    :context: close-figs
+
+    fig = gl.SmartFigure(2, 3)
+    fig[0, :] = curve1  # Spans entire first row
+
+    # Replace via single cell - new element inherits [0, :] span
+    fig[0, 1] = curve2
+
+    # curve2 now spans the entire first row
+    assert fig[0, 0][0] is fig[0, 1][0]  # Same element
+
+    # Replace via slice - new element inherits [0, :] span
+    fig[0, 0:2] = gl.Curve.from_function(lambda x: x**3, -2, 2)
+
+    fig.show()
+
+This behavior makes it intuitive to replace or add elements while maintaining your layout structure.
 
 
 Layout and Structure Control

--- a/docs/handbook/smart_figure_simple.rst
+++ b/docs/handbook/smart_figure_simple.rst
@@ -68,7 +68,7 @@ It is also possible to add elements to a preexisting figure using the :py:meth:`
     figure.add_elements(*[random_curve() for _ in range(3)])  # Adds to the top subplots
     figure.show()
 
-The :py:meth:`~graphinglib.SmartFigure.__setitem__` method can also be used to add or remove elements from specific subplots by specifying their position in the grid, exactly how `two-dimensional numpy arrays are indexed <https://numpy.org/doc/stable/user/basics.indexing.html>`_. Attributing ``None`` to a subplot will remove all its elements. Slicing is also supported to add elements to or remove elements from multiples rows or coklumns at once. Here are some examples:
+The :py:meth:`~graphinglib.SmartFigure.__setitem__` method can also be used to add or remove elements from specific subplots by specifying their position in the grid, exactly how `two-dimensional numpy arrays are indexed <https://numpy.org/doc/stable/user/basics.indexing.html>`_. Attributing ``None`` to a subplot will remove all its elements. Slicing is also supported to add elements to or remove elements from multiples rows or columns at once. Here are some examples:
 
 .. plot::
     :context: close-figs
@@ -81,10 +81,13 @@ The :py:meth:`~graphinglib.SmartFigure.__setitem__` method can also be used to a
     # Add a curve that spans the last two subplots of the bottom row
     figure[1, 1:] = random_curve()
 
-    # Add a curve to the second suplot
+    # Add a curve to the second subplot
     figure[0, 1] += [random_curve()]
 
     figure.show()
+
+.. tip::
+   When an element spans multiple cells, you can access, modify, or remove it by clicking on **any** cell it occupies. For example, to remove the curve that spans ``[1, 1:]``, you can use ``figure[1, 1] = None`` or ``figure[1, 2] = None``. See the :doc:`smart_figure_advanced` section for more details on multi-cell element access.
 
 The advantage of the :class:`~graphinglib.SmartFigure` class is that you can insert this object in itself:
 

--- a/graphinglib/smart_figure.py
+++ b/graphinglib/smart_figure.py
@@ -1357,8 +1357,14 @@ class SmartFigure:
             existing_row, existing_col = existing_key
 
             # Check if there's any overlap
-            row_overlap = not (row_slice.stop <= existing_row.start or row_slice.start >= existing_row.stop)
-            col_overlap = not (col_slice.stop <= existing_col.start or col_slice.start >= existing_col.stop)
+            row_overlap = not (
+                row_slice.stop <= existing_row.start
+                or row_slice.start >= existing_row.stop
+            )
+            col_overlap = not (
+                col_slice.stop <= existing_col.start
+                or col_slice.start >= existing_col.stop
+            )
 
             if row_overlap and col_overlap:
                 overlapping.append((existing_key, element))

--- a/graphinglib/smart_figure.py
+++ b/graphinglib/smart_figure.py
@@ -1004,12 +1004,14 @@ class SmartFigure:
             ``num_cols`` is set to 1, the key can be a single int or slice. Otherwise, the key must be a two-tuple.
         element : Plottable | Iterable[Plottable | None] | SmartFigure | None
             The element(s) to assign. Must be a Plottable, an iterable of Plottable objects, or a SmartFigure. If None,
-            the element at the specified key will be removed. Note that the exact slice used for inserting Plottables or
-            a SmartFigure must be provided to remove it.
+            any element overlapping with the specified key will be removed.
 
             .. note::
-                It is also possible to add a list of Plottables to a subplot already containing Plottables using the
-                ``+=`` operator.
+                - You can access and modify multi-cell subfigures by indexing any cell they occupy.
+                - Setting a cell to None will delete the entire subfigure occupying that cell.
+                - Assigning a new element to a cell with an existing element will replace the entire existing element.
+                - You can add elements to an existing subfigure using the ``+=`` operator.
+                - If the requested slice overlaps with multiple different subfigures, a GraphingException is raised.
 
         Examples
         --------
@@ -1031,10 +1033,14 @@ class SmartFigure:
             | Histogram               |
             +-------------------------+
 
-        We can add elements using the ``+=`` operator and remove them using ``None``::
+        We can add elements using the ``+=`` operator and remove them using ``None``. Notice that we can access
+        the multi-cell Histogram by indexing any cell it occupies::
 
             fig[0, 0] += [gl.Curve(x2, y2)]
             fig[0, 1] = None
+            fig[1, 0] = None  # This deletes the Histogram even though it spans both cells
+            # Or equivalently:
+            # fig[1, :] = None
 
         Which will result in the following layout::
 
@@ -1043,25 +1049,25 @@ class SmartFigure:
             | Curve      |            |
             | Curve      |            |
             +------------+------------+
-            | 1,0          1,1        |
-            | Histogram               |
-            +-------------------------+
+            | 1,0        | 1,1        |
+            |            |            |
+            +------------+------------+
 
-        We can also insert a nested SmartFigure into a specific region of the SmartFigure and remove the bottom plot::
+        We can also insert a nested SmartFigure. If it overlaps with existing elements, they will be replaced::
 
             subfigure = SmartFigure(num_rows=2, num_cols=1)
             subfigure.add_elements(gl.Heatmap(data1), gl.Heatmap(data2))
-            fig[0, 1] = subfigure
-            fig[1, :] = None
+            fig[0, 1] = subfigure  # Placed in the top-right cell
 
         Which will lead to the following layout::
 
             +------------+------------+
             | 0,0        | Heatmap    |
             | Curve      +------------+
-            |            | Heatmap    |
+            | Curve      | Heatmap    |
             +------------+------------+
             | 1,0        | 1,1        |
+            |            |            |
             +------------+------------+
         """
         if not any(
@@ -1074,10 +1080,26 @@ class SmartFigure:
             raise TypeError(
                 "Element must be a Plottable, an iterable of Plottables, or a SmartFigure."
             )
+
         key_ = self._validate_and_normalize_key(key)
-        if element is None:
-            self._elements.pop(key_, None)
-        else:
+
+        # Find all elements that overlap with the requested range
+        overlapping = self._get_overlapping_elements(key_)
+
+        if element is None:  # Deleting element(s)
+            if len(overlapping) == 0:
+                # No element to delete, do nothing
+                pass
+            elif len(overlapping) == 1:
+                # Delete the single overlapping element
+                self._elements.pop(overlapping[0][0])
+            else:
+                # Multiple elements overlap - raise exception
+                raise GraphingException(
+                    f"The requested slice {key} overlaps with multiple subfigures. "
+                    f"Cannot delete multiple subfigures at once. Please delete each subfigure separately."
+                )
+        else:  # Adding/replacing element
             # Normalize all iterables to lists for consistency
             if isinstance(element, Plottable):
                 el = [element]
@@ -1085,7 +1107,24 @@ class SmartFigure:
                 el = list(element)
             else:
                 el = element
-            self._elements[key_] = el
+
+            if len(overlapping) == 0:
+                # No overlap, just add the new element
+                self._elements[key_] = el
+            elif len(overlapping) == 1:
+                # Single element overlaps
+                existing_key = overlapping[0][0]
+
+                # Delete the existing element and add the new one
+                self._elements.pop(existing_key)
+                self._elements[existing_key] = el
+            else:
+                # Multiple elements overlap - raise exception
+                raise GraphingException(
+                    f"The requested slice {key} overlaps with multiple subfigures. "
+                    f"Cannot assign a new element to a position that overlaps with multiple subfigures. "
+                    f"Please remove the overlapping subfigures first or use a more specific slice."
+                )
 
     def __getitem__(
         self, key: int | slice | tuple[int | slice]
@@ -1105,17 +1144,39 @@ class SmartFigure:
             Otherwise, the key must be a two-tuple.
 
             .. note::
-                The exact slice of the element must be provided to access it. This means that if an element spans
-                multiple subplots, the given slice also needs to span these subplots.
+                If a subfigure spans multiple cells, you can access it by indexing any cell it occupies. For example,
+                if a subfigure spans ``[0, :]`` (entire first row), you can access it via ``fig[0, :]``, ``fig[0, 0]``,
+                or ``fig[0, 1]`` (assuming there are at least 2 columns). If the requested slice overlaps with multiple
+                different subfigures, a GraphingException is raised.
 
         Returns
         -------
         list[Plottable] | SmartFigure
             The element(s) at the specified key, which can be a list of Plottables or a SmartFigure. If there is no
-            elements at the given key, an empty list is returned.
+            element at the given key, an empty list is returned.
         """
         key_ = self._validate_and_normalize_key(key)
-        return self._elements.get(key_, [])
+
+        # First, check if there's an exact match
+        if key_ in self._elements:
+            return self._elements[key_]
+
+        # If not, find all elements that overlap with the requested range
+        overlapping = self._get_overlapping_elements(key_)
+
+        if len(overlapping) == 0:
+            # No element at this location
+            return []
+        elif len(overlapping) == 1:
+            # Single element overlaps with this location
+            return overlapping[0][1]
+        else:
+            # Multiple elements overlap with this slice
+            raise GraphingException(
+                f"The requested slice {key} overlaps with multiple subfigures. "
+                f"Cannot return a single element. Please use a more specific slice that "
+                f"matches only one subfigure, or handle each subfigure separately."
+            )
 
     def __iter__(self) -> Iterator[list[Plottable] | SmartFigure]:
         """
@@ -1272,6 +1333,37 @@ class SmartFigure:
         return isinstance(item, Iterable) and all(
             isinstance(el, (Plottable, type(None))) for el in item
         )
+
+    def _get_overlapping_elements(
+        self, key: tuple[slice, slice]
+    ) -> list[tuple[tuple[slice, slice], list[Plottable] | SmartFigure]]:
+        """
+        Finds all elements that overlap with the specified key range.
+
+        Parameters
+        ----------
+        key : tuple[slice, slice]
+            The key range to check for overlaps, as a tuple of two slices.
+
+        Returns
+        -------
+        list[tuple[tuple[slice, slice], list[Plottable] | SmartFigure]]
+            A list of tuples, each containing the key and element that overlaps with the specified range.
+        """
+        overlapping = []
+        row_slice, col_slice = key
+
+        for existing_key, element in self._elements.items():
+            existing_row, existing_col = existing_key
+
+            # Check if there's any overlap
+            row_overlap = not (row_slice.stop <= existing_row.start or row_slice.start >= existing_row.stop)
+            col_overlap = not (col_slice.stop <= existing_col.start or col_slice.start >= existing_col.stop)
+
+            if row_overlap and col_overlap:
+                overlapping.append((existing_key, element))
+
+        return overlapping
 
     def add_elements(
         self,


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->

As discussed in #649, this PR implements the clicking behaviour, which allows user to index any part of a subplot to modify it even though it spans more than one cell. My implementation basically adds the `_get_overlapping_elements` method, which returns a list of elements that overlap with the given slice, along with their own slice. With this, we are able to check that the given slice does not contain more than one subplot and raise errors appropriately. This also has the side effect of raising errors whenever you try to create an overlapping subplot (see #647) and in the end I think this is for the better. As for some points that were ambiguous in the issue, here are my choices:

- Since we only allow to get/set elements if the `_get_overlapping_elements` method returns 0 or 1 element, slicing a combination of existing subfigures will return an error.
- If your slice includes a subfigure and some empty space, the `_get_overlapping_elements` method will return only one element so get/set is not forbidden, and this allows you to, for example, add an element into the subfigure that is not `None`.

I think this is probably the easiest and most intuitive way to implement this. Please feel free to let me know what you think! I will be leaving this PR as a draft until we are sure this is the way to go and until I can then document this behaviour in the handbook.


## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [x] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/latest/contributing/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [N/A] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request).
- [x] Links to the related issue (#....)
