### PR TITLE
Converted "default" to Inherit type and marker

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,6 +108,7 @@ intersphinx_mapping = {
 autodoc_type_aliases = {
     "Iterable": "Iterable",
     "ArrayLike": "ArrayLike",
+    "Inherit": "Inherit",
 }
 
 autosummary_generate = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,6 @@ intersphinx_mapping = {
 autodoc_type_aliases = {
     "Iterable": "Iterable",
     "ArrayLike": "ArrayLike",
-    "Inherit": "Inherit",
 }
 
 autosummary_generate = True

--- a/docs/handbook/smart_figure_advanced.rst
+++ b/docs/handbook/smart_figure_advanced.rst
@@ -393,8 +393,8 @@ Control the overall figure size with the ``size`` parameter:
 .. plot::
     :context: close-figs
 
-    # Use "default" to let the style file determine the size
-    fig = gl.SmartFigure(size="default", elements=curve1)
+    # Use INHERIT to let the style file determine the size
+    fig = gl.SmartFigure(size=gl.INHERIT, elements=curve1)
     fig.show()
 
 .. note::

--- a/docs/release_notes/upcoming_changes/652.bugfix.rst
+++ b/docs/release_notes/upcoming_changes/652.bugfix.rst
@@ -1,3 +1,3 @@
 Bugfix for `Shapes` in matplotlib styles
 ----------------------------------------
-Fixed a bug where the `Shapes` class was not replacing its `"default"` values when plotting, which caused errors when using matplotlib styles that have default values for these parameters..
+Fixed a bug where the `Shapes` class was not replacing its `Inherit` values when plotting, which caused errors when using matplotlib styles that have default values for these parameters..

--- a/docs/release_notes/upcoming_changes/666.improvement.rst
+++ b/docs/release_notes/upcoming_changes/666.improvement.rst
@@ -1,0 +1,7 @@
+Typing for default/inheritance
+------------------------------
+
+GraphingLib's inheritance sentinel was changed from a string to a marker:
+
+- ``Inherit`` is now the marker type used in annotations (for example ``float | Inherit``).
+- ``INHERIT`` is the value used at runtime for defaults, comparisons, and resets.

--- a/examples/arrow_styles.py
+++ b/examples/arrow_styles.py
@@ -6,8 +6,10 @@ _thumb: .4, .4
 """
 
 import graphinglib as gl
+from typing import Literal
 
-arrow_styles = ["->", "-|>", "-[", "]->", "simple", "fancy", "wedge"]
+ArrowStyle = Literal["->", "-|>", "-[", "]->", "simple", "fancy", "wedge"]
+arrow_styles: list[ArrowStyle] = ["->", "-|>", "-[", "]->", "simple", "fancy", "wedge"]
 
 one_sided_arrows = []
 for i, style in enumerate(reversed(arrow_styles)):

--- a/graphinglib/__init__.py
+++ b/graphinglib/__init__.py
@@ -52,6 +52,7 @@ from .graph_elements import (
     Vlines,
 )
 from .legend_artists import LegendElement, LegendLine, LegendMarker, LegendPatch
+from .inherit import INHERIT, Inherit
 from .multifigure import MultiFigure
 from .shapes import Arrow, Circle, Ellipse, Line, Polygon, Rectangle
 from .smart_figure import SmartFigure, SmartFigureWCS, SmartTwinAxis
@@ -94,6 +95,8 @@ __all__ = [
     "LegendLine",
     "LegendMarker",
     "LegendPatch",
+    "INHERIT",
+    "Inherit",
     "MultiFigure",
     "Arrow",
     "Circle",

--- a/graphinglib/data_plotting_1d.py
+++ b/graphinglib/data_plotting_1d.py
@@ -309,9 +309,7 @@ class Curve(Plottable1D, MathematicalObject):
         return self._errorbars_line_width
 
     @errorbars_line_width.setter
-    def errorbars_line_width(
-        self, errorbars_line_width: float | Inherit
-    ) -> None:
+    def errorbars_line_width(self, errorbars_line_width: float | Inherit) -> None:
         self._errorbars_line_width = errorbars_line_width
 
     @property
@@ -367,9 +365,7 @@ class Curve(Plottable1D, MathematicalObject):
         return self._error_curves_line_width
 
     @error_curves_line_width.setter
-    def error_curves_line_width(
-        self, error_curves_line_width: float | Inherit
-    ) -> None:
+    def error_curves_line_width(self, error_curves_line_width: float | Inherit) -> None:
         self._error_curves_line_width = error_curves_line_width
 
     @property

--- a/graphinglib/data_plotting_1d.py
+++ b/graphinglib/data_plotting_1d.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from .inherit import INHERIT, Inherit, is_inherit
+
 from copy import deepcopy
 from dataclasses import dataclass
 from types import NoneType
-from typing import Callable, Literal, Optional, Protocol, runtime_checkable
+from typing import Callable, Optional, Protocol, runtime_checkable
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -133,10 +135,10 @@ class Curve(Plottable1D, MathematicalObject):
         x_data: ArrayLike,
         y_data: ArrayLike,
         label: Optional[str] = None,
-        color: str = "default",
-        line_width: float | Literal["default"] = "default",
-        line_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
     ) -> None:
         self.handle = None
         self._x_data = np.asarray(x_data)
@@ -173,10 +175,10 @@ class Curve(Plottable1D, MathematicalObject):
         x_min: float,
         x_max: float,
         label: Optional[str] = None,
-        color: str = "default",
-        line_width: float | Literal["default"] = "default",
-        line_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         number_of_points: int = 500,
     ) -> Self:
         """
@@ -263,11 +265,11 @@ class Curve(Plottable1D, MathematicalObject):
         self._color = color
 
     @property
-    def line_width(self) -> float | Literal["default"]:
+    def line_width(self) -> float | Inherit:
         return self._line_width
 
     @line_width.setter
-    def line_width(self, line_width: float | Literal["default"]) -> None:
+    def line_width(self, line_width: float | Inherit) -> None:
         self._line_width = line_width
 
     @property
@@ -279,11 +281,11 @@ class Curve(Plottable1D, MathematicalObject):
         self._line_style = line_style
 
     @property
-    def alpha(self) -> float | Literal["default"]:
+    def alpha(self) -> float | Inherit:
         return self._alpha
 
     @alpha.setter
-    def alpha(self, alpha: float | Literal["default"]) -> None:
+    def alpha(self, alpha: float | Inherit) -> None:
         self._alpha = alpha
 
     @property
@@ -303,29 +305,29 @@ class Curve(Plottable1D, MathematicalObject):
         self._errorbars_color = errorbars_color
 
     @property
-    def errorbars_line_width(self) -> float | Literal["default"]:
+    def errorbars_line_width(self) -> float | Inherit:
         return self._errorbars_line_width
 
     @errorbars_line_width.setter
     def errorbars_line_width(
-        self, errorbars_line_width: float | Literal["default"]
+        self, errorbars_line_width: float | Inherit
     ) -> None:
         self._errorbars_line_width = errorbars_line_width
 
     @property
-    def cap_thickness(self) -> float | Literal["default"]:
+    def cap_thickness(self) -> float | Inherit:
         return self._cap_thickness
 
     @cap_thickness.setter
-    def cap_thickness(self, cap_thickness: float | Literal["default"]) -> None:
+    def cap_thickness(self, cap_thickness: float | Inherit) -> None:
         self._cap_thickness = cap_thickness
 
     @property
-    def cap_width(self) -> float | Literal["default"]:
+    def cap_width(self) -> float | Inherit:
         return self._cap_width
 
     @cap_width.setter
-    def cap_width(self, cap_width: float | Literal["default"]) -> None:
+    def cap_width(self, cap_width: float | Inherit) -> None:
         self._cap_width = cap_width
 
     @property
@@ -361,12 +363,12 @@ class Curve(Plottable1D, MathematicalObject):
         self._error_curves_line_style = error_curves_line_style
 
     @property
-    def error_curves_line_width(self) -> float | Literal["default"]:
+    def error_curves_line_width(self) -> float | Inherit:
         return self._error_curves_line_width
 
     @error_curves_line_width.setter
     def error_curves_line_width(
-        self, error_curves_line_width: float | Literal["default"]
+        self, error_curves_line_width: float | Inherit
     ) -> None:
         self._error_curves_line_width = error_curves_line_width
 
@@ -525,10 +527,10 @@ class Curve(Plottable1D, MathematicalObject):
         x1: float,
         x2: float,
         label: Optional[str] = None,
-        color: str = "default",
-        line_width: float | Literal["default"] = "default",
-        line_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         copy_first: bool = False,
     ) -> Self:
         """
@@ -571,13 +573,13 @@ class Curve(Plottable1D, MathematicalObject):
             copy._y_data = y_data
             if label is not None:
                 copy._label = label
-            if color != "default":
+            if color != INHERIT:
                 copy._color = color
-            if line_width != "default":
+            if line_width != INHERIT:
                 copy._line_width = line_width
-            if line_style != "default":
+            if line_style != INHERIT:
                 copy._line_style = line_style
-            if alpha != "default":
+            if alpha != INHERIT:
                 copy._alpha = alpha
             return copy
         else:
@@ -588,10 +590,10 @@ class Curve(Plottable1D, MathematicalObject):
         y1: float,
         y2: float,
         label: Optional[str] = None,
-        color: str = "default",
-        line_width: float | Literal["default"] = "default",
-        line_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         copy_first: bool = False,
     ) -> Self:
         """
@@ -634,13 +636,13 @@ class Curve(Plottable1D, MathematicalObject):
             copy._y_data = y_data
             if label is not None:
                 copy._label = label
-            if color != "default":
+            if color != INHERIT:
                 copy._color = color
-            if line_width != "default":
+            if line_width != INHERIT:
                 copy._line_width = line_width
-            if line_style != "default":
+            if line_style != INHERIT:
                 copy._line_style = line_style
-            if alpha != "default":
+            if alpha != INHERIT:
                 copy._alpha = alpha
             return copy
         else:
@@ -650,10 +652,10 @@ class Curve(Plottable1D, MathematicalObject):
         self,
         x_error: Optional[ArrayLike] = None,
         y_error: Optional[ArrayLike] = None,
-        cap_width: float | Literal["default"] = "default",
-        errorbars_color: str = "default",
-        errorbars_line_width: float | Literal["default"] = "default",
-        cap_thickness: float | Literal["default"] = "default",
+        cap_width: float | Inherit = INHERIT,
+        errorbars_color: str | Inherit = INHERIT,
+        errorbars_line_width: float | Inherit = INHERIT,
+        cap_thickness: float | Inherit = INHERIT,
     ) -> None:
         """
         Adds errorbars to the :class:`~graphinglib.data_plotting_1d.Curve`.
@@ -691,10 +693,10 @@ class Curve(Plottable1D, MathematicalObject):
     def add_error_curves(
         self,
         y_error: Optional[ArrayLike] = None,
-        error_curves_color: str = "default",
-        error_curves_line_style: str = "default",
-        error_curves_line_width: float | Literal["default"] = "default",
-        error_curves_fill_between: bool | Literal["default"] = "default",
+        error_curves_color: str | Inherit = INHERIT,
+        error_curves_line_style: str | Inherit = INHERIT,
+        error_curves_line_width: float | Inherit = INHERIT,
+        error_curves_fill_between: bool | Inherit = INHERIT,
     ) -> None:
         """
         Adds error curves to the :class:`~graphinglib.data_plotting_1d.Curve`.
@@ -760,12 +762,12 @@ class Curve(Plottable1D, MathematicalObject):
         x: float,
         interpolation_method: str = "linear",
         label: Optional[str] = None,
-        face_color: str = "default",
-        edge_color: str = "default",
-        marker_size: float | Literal["default"] = "default",
-        marker_style: str = "default",
-        line_width: float | Literal["default"] = "default",
-        alpha: float | Literal["default"] = "default",
+        face_color: str | Inherit = INHERIT,
+        edge_color: str | Inherit = INHERIT,
+        marker_size: float | Inherit = INHERIT,
+        marker_style: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
     ) -> Point:
         """
         Creates a point on the curve at a given x value.
@@ -862,12 +864,12 @@ class Curve(Plottable1D, MathematicalObject):
         y: float,
         interpolation_method: str = "linear",
         label: str | None = None,
-        face_color: str = "default",
-        edge_color: str = "default",
-        marker_size: float | Literal["default"] = "default",
-        marker_style: str = "default",
-        line_width: float | Literal["default"] = "default",
-        alpha: float | Literal["default"] = "default",
+        face_color: str | Inherit = INHERIT,
+        edge_color: str | Inherit = INHERIT,
+        marker_size: float | Inherit = INHERIT,
+        marker_style: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
     ) -> list[Point]:
         """
         Gets the points on the curve at a given y value. Can return multiple Point objects if the curve crosses the y
@@ -929,10 +931,10 @@ class Curve(Plottable1D, MathematicalObject):
     def create_derivative_curve(
         self,
         label: Optional[str] = None,
-        color: str = "default",
-        line_width: float | Literal["default"] = "default",
-        line_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         copy_first: bool = False,
     ) -> Self:
         """
@@ -970,13 +972,13 @@ class Curve(Plottable1D, MathematicalObject):
             copy._y_data = y_data
             if label is not None:
                 copy._label = label
-            if color != "default":
+            if color != INHERIT:
                 copy._color = color
-            if line_width != "default":
+            if line_width != INHERIT:
                 copy._line_width = line_width
-            if line_style != "default":
+            if line_style != INHERIT:
                 copy._line_style = line_style
-            if alpha != "default":
+            if alpha != INHERIT:
                 copy._alpha = alpha
             return copy
         else:
@@ -986,10 +988,10 @@ class Curve(Plottable1D, MathematicalObject):
         self,
         initial_value: float = 0,
         label: Optional[str] = None,
-        color: str = "default",
-        line_width: float | Literal["default"] = "default",
-        line_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         copy_first: bool = False,
     ) -> Self:
         """
@@ -1032,13 +1034,13 @@ class Curve(Plottable1D, MathematicalObject):
             copy._y_data = y_data
             if label is not None:
                 copy._label = label
-            if color != "default":
+            if color != INHERIT:
                 copy._color = color
-            if line_width != "default":
+            if line_width != INHERIT:
                 copy._line_width = line_width
-            if line_style != "default":
+            if line_style != INHERIT:
                 copy._line_style = line_style
-            if alpha != "default":
+            if alpha != INHERIT:
                 copy._alpha = alpha
             return copy
         else:
@@ -1050,10 +1052,10 @@ class Curve(Plottable1D, MathematicalObject):
         self,
         x: float,
         label: Optional[str] = None,
-        color: str = "default",
-        line_width: float | Literal["default"] = "default",
-        line_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         copy_first: bool = False,
     ) -> Self:
         """
@@ -1096,13 +1098,13 @@ class Curve(Plottable1D, MathematicalObject):
             copy._y_data = y_data
             if label is not None:
                 copy._label = label
-            if color != "default":
+            if color != INHERIT:
                 copy._color = color
-            if line_width != "default":
+            if line_width != INHERIT:
                 copy._line_width = line_width
-            if line_style != "default":
+            if line_style != INHERIT:
                 copy._line_style = line_style
-            if alpha != "default":
+            if alpha != INHERIT:
                 copy._alpha = alpha
             return copy
         else:
@@ -1115,10 +1117,10 @@ class Curve(Plottable1D, MathematicalObject):
         self,
         x: float,
         label: Optional[str] = None,
-        color: str = "default",
-        line_width: float | Literal["default"] = "default",
-        line_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         copy_first: bool = False,
     ) -> Self:
         """
@@ -1161,13 +1163,13 @@ class Curve(Plottable1D, MathematicalObject):
             copy._y_data = y_data
             if label is not None:
                 copy._label = label
-            if color != "default":
+            if color != INHERIT:
                 copy._color = color
-            if line_width != "default":
+            if line_width != INHERIT:
                 copy._line_width = line_width
-            if line_style != "default":
+            if line_style != INHERIT:
                 copy._line_style = line_style
-            if alpha != "default":
+            if alpha != INHERIT:
                 copy._alpha = alpha
             return copy
         else:
@@ -1218,7 +1220,7 @@ class Curve(Plottable1D, MathematicalObject):
         x1: float,
         x2: float,
         fill_between: bool = False,
-        fill_color: str = "default",
+        fill_color: str | Inherit = INHERIT,
         other_curve: Optional[Self] = None,
     ) -> float:
         """
@@ -1341,12 +1343,12 @@ class Curve(Plottable1D, MathematicalObject):
         self,
         other: Self,
         labels: Optional[list[str] | str] = None,
-        face_colors: list[str] | str = "default",
-        edge_colors: list[str] | str = "default",
-        marker_sizes: list[float] | float | Literal["default"] = "default",
-        marker_styles: list[str] | str = "default",
-        edge_widths: list[float] | float | Literal["default"] = "default",
-        alphas: list[float] | float | Literal["default"] = "default",
+        face_colors: list[str] | str | Inherit = INHERIT,
+        edge_colors: list[str] | str | Inherit = INHERIT,
+        marker_sizes: list[float] | float | Inherit = INHERIT,
+        marker_styles: list[str] | str | Inherit = INHERIT,
+        edge_widths: list[float] | float | Inherit = INHERIT,
+        alphas: list[float] | float | Inherit = INHERIT,
     ) -> list[Point]:
         """
         Creates the intersection Points between two curves.
@@ -1483,7 +1485,7 @@ class Curve(Plottable1D, MathematicalObject):
                     ),
                 }
             )
-            params = {k: v for k, v in params.items() if v != "default"}
+            params = {k: v for k, v in params.items() if v != INHERIT}
             self.handle = axes.errorbar(
                 self._x_data,
                 self._y_data,
@@ -1494,7 +1496,7 @@ class Curve(Plottable1D, MathematicalObject):
                 **params,
             )
         else:
-            params = {k: v for k, v in params.items() if v != "default"}
+            params = {k: v for k, v in params.items() if v != INHERIT}
             self.handle = axes.errorbar(
                 self._x_data,
                 self._y_data,
@@ -1532,7 +1534,7 @@ class Curve(Plottable1D, MathematicalObject):
                 ),
             }
 
-            params = {k: v for k, v in params.items() if v != "default"}
+            params = {k: v for k, v in params.items() if v != INHERIT}
 
             axes.plot(
                 self._x_data,
@@ -1559,7 +1561,7 @@ class Curve(Plottable1D, MathematicalObject):
                 if self._fill_between_color != "same as curve"
                 else self.handle[0].get_color()
             )
-            params = {k: v for k, v in params.items() if v != "default"}
+            params = {k: v for k, v in params.items() if v != INHERIT}
             if self._fill_between_other_curve:
                 self_y_data = self._y_data
                 self_x_data = self._x_data
@@ -1637,15 +1639,15 @@ class Scatter(Plottable1D, MathematicalObject):
         x_data: ArrayLike,
         y_data: ArrayLike,
         label: Optional[str] = None,
-        face_color: str | ArrayLike | NoneType = "default",
-        edge_color: str | ArrayLike | NoneType = "default",
-        color_map: str | Colormap = "default",
+        face_color: str | ArrayLike | NoneType | Inherit = INHERIT,
+        edge_color: str | ArrayLike | NoneType | Inherit = INHERIT,
+        color_map: str | Colormap | Inherit = INHERIT,
         color_map_range: Optional[tuple[float, float]] = None,
-        show_color_bar: bool | Literal["default"] = "default",
-        marker_size: float | Literal["default"] = "default",
-        marker_edge_width: float | Literal["default"] = "default",
-        marker_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        show_color_bar: bool | Inherit = INHERIT,
+        marker_size: float | Inherit = INHERIT,
+        marker_edge_width: float | Inherit = INHERIT,
+        marker_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
     ) -> None:
         """
         This class implements a general scatter plot.
@@ -1717,15 +1719,15 @@ class Scatter(Plottable1D, MathematicalObject):
         x_min: float,
         x_max: float,
         label: Optional[str] = None,
-        face_color: str | ArrayLike | NoneType = "default",
-        edge_color: str | ArrayLike | NoneType = "default",
-        color_map: str | Colormap = "default",
+        face_color: str | ArrayLike | NoneType | Inherit = INHERIT,
+        edge_color: str | ArrayLike | NoneType | Inherit = INHERIT,
+        color_map: str | Colormap | Inherit = INHERIT,
         color_map_range: Optional[tuple[float, float]] = None,
-        show_color_bar: bool | Literal["default"] = "default",
-        marker_size: int | Literal["default"] = "default",
-        marker_edge_width: float | Literal["default"] = "default",
-        marker_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        show_color_bar: bool | Inherit = INHERIT,
+        marker_size: int | Inherit = INHERIT,
+        marker_edge_width: float | Inherit = INHERIT,
+        marker_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         number_of_points: int = 30,
     ) -> Self:
         """
@@ -1872,11 +1874,11 @@ class Scatter(Plottable1D, MathematicalObject):
         self._show_color_bar = show_color_bar
 
     @property
-    def marker_size(self) -> float | Literal["default"]:
+    def marker_size(self) -> float | Inherit:
         return self._marker_size
 
     @marker_size.setter
-    def marker_size(self, marker_size: float | Literal["default"]) -> None:
+    def marker_size(self, marker_size: float | Inherit) -> None:
         self._marker_size = marker_size
 
     @property
@@ -1896,11 +1898,11 @@ class Scatter(Plottable1D, MathematicalObject):
         self._marker_style = marker_style
 
     @property
-    def alpha(self) -> float | Literal["default"]:
+    def alpha(self) -> float | Inherit:
         return self._alpha
 
     @alpha.setter
-    def alpha(self, alpha: float | Literal["default"]) -> None:
+    def alpha(self, alpha: float | Inherit) -> None:
         self._alpha = alpha
 
     @property
@@ -2076,15 +2078,15 @@ class Scatter(Plottable1D, MathematicalObject):
         x_min: float,
         x_max: float,
         label: Optional[str] = None,
-        face_color: str | ArrayLike | NoneType = "default",
-        edge_color: str | ArrayLike | NoneType = "default",
-        color_map: str | Colormap = "default",
+        face_color: str | ArrayLike | NoneType | Inherit = INHERIT,
+        edge_color: str | ArrayLike | NoneType | Inherit = INHERIT,
+        color_map: str | Colormap | Inherit = INHERIT,
         color_map_range: Optional[tuple[float, float]] = None,
-        show_color_bar: bool | Literal["default"] = "default",
-        marker_size: float | Literal["default"] = "default",
-        marker_edge_width: float | Literal["default"] = "default",
-        marker_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        show_color_bar: bool | Inherit = INHERIT,
+        marker_size: float | Inherit = INHERIT,
+        marker_edge_width: float | Inherit = INHERIT,
+        marker_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         copy_first: bool = False,
     ) -> Self:
         """
@@ -2141,23 +2143,23 @@ class Scatter(Plottable1D, MathematicalObject):
             copy._y_data = self._y_data[mask]
             if label is not None:
                 copy._label = label
-            if face_color != "default":
+            if face_color != INHERIT:
                 copy._face_color = face_color
-            if edge_color != "default":
+            if edge_color != INHERIT:
                 copy._edge_color = edge_color
-            if color_map != "default":
+            if color_map != INHERIT:
                 copy._color_map = color_map
             if color_map_range:
                 copy._color_map_range = color_map_range
-            if show_color_bar != "default":
+            if show_color_bar != INHERIT:
                 copy._show_color_bar = show_color_bar
-            if marker_size != "default":
+            if marker_size != INHERIT:
                 copy._marker_size = marker_size
-            if marker_edge_width != "default":
+            if marker_edge_width != INHERIT:
                 copy._marker_edge_width = marker_edge_width
-            if marker_style != "default":
+            if marker_style != INHERIT:
                 copy._marker_style = marker_style
-            if alpha != "default":
+            if alpha != INHERIT:
                 copy._alpha = alpha
             return copy
         else:
@@ -2181,15 +2183,15 @@ class Scatter(Plottable1D, MathematicalObject):
         y_min: float,
         y_max: float,
         label: Optional[str] = None,
-        face_color: str | ArrayLike | NoneType = "default",
-        edge_color: str | ArrayLike | NoneType = "default",
-        color_map: str | Colormap | Literal["default"] = "default",
+        face_color: str | ArrayLike | NoneType | Inherit = INHERIT,
+        edge_color: str | ArrayLike | NoneType | Inherit = INHERIT,
+        color_map: str | Colormap | Inherit = INHERIT,
         color_map_range: Optional[tuple[float, float]] = None,
-        show_color_bar: bool | Literal["default"] = "default",
-        marker_size: float | Literal["default"] = "default",
-        marker_edge_width: float | Literal["default"] = "default",
-        marker_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        show_color_bar: bool | Inherit = INHERIT,
+        marker_size: float | Inherit = INHERIT,
+        marker_edge_width: float | Inherit = INHERIT,
+        marker_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         copy_first: bool = False,
     ) -> Self:
         """
@@ -2246,23 +2248,23 @@ class Scatter(Plottable1D, MathematicalObject):
             copy._y_data = self._y_data[mask]
             if label is not None:
                 copy._label = label
-            if face_color != "default":
+            if face_color != INHERIT:
                 copy._face_color = face_color
-            if edge_color != "default":
+            if edge_color != INHERIT:
                 copy._edge_color = edge_color
-            if color_map != "default":
+            if color_map != INHERIT:
                 copy._color_map = color_map
             if color_map_range:
                 copy._color_map_range = color_map_range
-            if show_color_bar != "default":
+            if show_color_bar != INHERIT:
                 copy._show_color_bar = show_color_bar
-            if marker_size != "default":
+            if marker_size != INHERIT:
                 copy._marker_size = marker_size
-            if marker_edge_width != "default":
+            if marker_edge_width != INHERIT:
                 copy._marker_edge_width = marker_edge_width
-            if marker_style != "default":
+            if marker_style != INHERIT:
                 copy._marker_style = marker_style
-            if alpha != "default":
+            if alpha != INHERIT:
                 copy._alpha = alpha
             return copy
         else:
@@ -2285,10 +2287,10 @@ class Scatter(Plottable1D, MathematicalObject):
         self,
         x_error: Optional[ArrayLike] = None,
         y_error: Optional[ArrayLike] = None,
-        cap_width: float | Literal["default"] = "default",
-        errorbars_color: str = "default",
-        errorbars_line_width: float | Literal["default"] = "default",
-        cap_thickness: float | Literal["default"] = "default",
+        cap_width: float | Inherit = INHERIT,
+        errorbars_color: str | Inherit = INHERIT,
+        errorbars_line_width: float | Inherit = INHERIT,
+        cap_thickness: float | Inherit = INHERIT,
     ) -> None:
         """
         Adds errorbars to the scatter plot.
@@ -2385,12 +2387,12 @@ class Scatter(Plottable1D, MathematicalObject):
         x: float,
         interpolation_method: str = "linear",
         label: Optional[str] = None,
-        face_color: str = "default",
-        edge_color: str = "default",
-        marker_size: float | Literal["default"] = "default",
-        marker_edge_width: float | Literal["default"] = "default",
-        marker_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        face_color: str | Inherit = INHERIT,
+        edge_color: str | Inherit = INHERIT,
+        marker_size: float | Inherit = INHERIT,
+        marker_edge_width: float | Inherit = INHERIT,
+        marker_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
     ) -> Point:
         """
         Creates a Point on the curve at a given x value.
@@ -2488,12 +2490,12 @@ class Scatter(Plottable1D, MathematicalObject):
         y: float,
         interpolation_method: str = "linear",
         label: Optional[str] = None,
-        face_color: str = "default",
-        edge_color: str = "default",
-        marker_size: float | Literal["default"] = "default",
-        marker_edge_width: float | Literal["default"] = "default",
-        marker_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        face_color: str | Inherit = INHERIT,
+        edge_color: str | Inherit = INHERIT,
+        marker_size: float | Inherit = INHERIT,
+        marker_edge_width: float | Inherit = INHERIT,
+        marker_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
     ) -> list[Point]:
         """
         Creates the Points on the curve at a given y value. Can return multiple Points if the curve crosses the y value
@@ -2606,7 +2608,7 @@ class Scatter(Plottable1D, MathematicalObject):
         if self._face_color is None:
             # Set to transparent
             mpl_face_color = "none"
-        elif isinstance(self._face_color, str) and self._face_color == "default":
+        elif is_inherit(self._face_color):
             # Use color cycle (figure uses a matplotlib style)
             mpl_face_color = None
         elif isinstance(self._face_color, str) and self._face_color == "color cycle":
@@ -2620,7 +2622,7 @@ class Scatter(Plottable1D, MathematicalObject):
         if self._edge_color is None:
             # Set to transparent
             mpl_edge_color = "none"
-        elif isinstance(self._edge_color, str) and self._edge_color == "default":
+        elif is_inherit(self._edge_color):
             # Use color cycle (figure uses a matplotlib style)
             mpl_edge_color = None
         elif isinstance(self._edge_color, str) and self._edge_color == "color cycle":
@@ -2668,7 +2670,7 @@ class Scatter(Plottable1D, MathematicalObject):
             "linewidth": self._marker_edge_width,
             "alpha": self._alpha,
         }
-        params = {k: v for k, v in params.items() if v != "default"}
+        params = {k: v for k, v in params.items() if v != INHERIT}
         params["facecolors"] = mpl_face_color
         params["edgecolors"] = mpl_edge_color
         self.handle = axes.scatter(
@@ -2684,9 +2686,7 @@ class Scatter(Plottable1D, MathematicalObject):
                 raise ValueError(
                     "Errorbars color cannot be None. Please set the errorbars color to a valid color."
                 )
-            elif isinstance(self._errorbars_color, str) and (
-                self._errorbars_color == "default"
-            ):
+            elif is_inherit(self._errorbars_color):
                 # Use color cycle
                 mpl_errorbars_color = None
             elif (
@@ -2716,9 +2716,7 @@ class Scatter(Plottable1D, MathematicalObject):
                 "capthick": self._cap_thickness,
                 "linestyle": "none",
             }
-            errorbar_params = {
-                k: v for k, v in errorbar_params.items() if v != "default"
-            }
+            errorbar_params = {k: v for k, v in errorbar_params.items() if v != INHERIT}
             errorbar_params["ecolor"] = mpl_errorbars_color
             self.errorbars_handle = axes.errorbar(
                 self._x_data,
@@ -2732,10 +2730,16 @@ class Scatter(Plottable1D, MathematicalObject):
         if (
             self._show_color_bar
             and self._face_color is not None
+            and not is_inherit(self._face_color)
             and not isinstance(self.face_color, str)
         ):
             # Create color bar from face color intensities
-            color_map = plt.get_cmap(self._color_map)
+            color_map_name = (
+                plt.rcParams["image.cmap"]
+                if is_inherit(self._color_map)
+                else self._color_map
+            )
+            color_map = plt.get_cmap(color_map_name)
 
             # Sets the data range that the color map on the color bar will cover.
             # Otherwise, it will be calculated from the array of intensities.
@@ -2753,10 +2757,16 @@ class Scatter(Plottable1D, MathematicalObject):
         if (
             self._show_color_bar
             and self._edge_color is not None
+            and not is_inherit(self._edge_color)
             and not isinstance(self.edge_color, str)
         ):
             # Create color bar from edge color intensities
-            color_map = plt.get_cmap(self._color_map)
+            color_map_name = (
+                plt.rcParams["image.cmap"]
+                if is_inherit(self._color_map)
+                else self._color_map
+            )
+            color_map = plt.get_cmap(color_map_name)
 
             # Sets the data range that the color map on the color bar will cover.
             # Otherwise, it will be calculated from the array of intensities.
@@ -2819,14 +2829,14 @@ class Histogram(Plottable1D):
         data: ArrayLike,
         bins: int,
         label: Optional[str] = None,
-        face_color: str = "default",
-        edge_color: str = "default",
-        hist_type: str = "default",
-        alpha: float | Literal["default"] = "default",
-        line_width: float | Literal["default"] = "default",
-        normalize: bool | Literal["default"] = "default",
-        orientation: str = "default",
-        show_params: bool | Literal["default"] = "default",
+        face_color: str | Inherit = INHERIT,
+        edge_color: str | Inherit = INHERIT,
+        hist_type: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        normalize: bool | Inherit = INHERIT,
+        orientation: str | Inherit = INHERIT,
+        show_params: bool | Inherit = INHERIT,
     ) -> None:
         """
         This class implements a general histogram.
@@ -2897,14 +2907,14 @@ class Histogram(Plottable1D):
         fit: Fit,
         bins: int,
         label: Optional[str] = None,
-        face_color: str = "default",
-        edge_color: str = "default",
-        hist_type: str = "default",
-        alpha: int | Literal["default"] = "default",
-        line_width: int | Literal["default"] = "default",
-        normalize: bool | Literal["default"] = "default",
-        orientation: str = "default",
-        show_params: bool | Literal["default"] = "default",
+        face_color: str | Inherit = INHERIT,
+        edge_color: str | Inherit = INHERIT,
+        hist_type: str | Inherit = INHERIT,
+        alpha: int | Inherit = INHERIT,
+        line_width: int | Inherit = INHERIT,
+        normalize: bool | Inherit = INHERIT,
+        orientation: str | Inherit = INHERIT,
+        show_params: bool | Inherit = INHERIT,
     ) -> Self:
         """
         Calculates the residuals of a fit and plots them as a histogram.
@@ -3162,11 +3172,11 @@ class Histogram(Plottable1D):
     def add_pdf(
         self,
         type: str = "normal",
-        show_mean: bool | Literal["default"] = "default",
-        show_std: bool | Literal["default"] = "default",
-        curve_color: str | Literal["default"] = "default",
-        mean_color: str | Literal["default"] = "default",
-        std_color: str | Literal["default"] = "default",
+        show_mean: bool | Inherit = INHERIT,
+        show_std: bool | Inherit = INHERIT,
+        curve_color: str | Inherit = INHERIT,
+        mean_color: str | Inherit = INHERIT,
+        std_color: str | Inherit = INHERIT,
     ) -> None:
         """
         Shows the probability density function of the histogram.
@@ -3237,17 +3247,17 @@ class Histogram(Plottable1D):
         params = {
             "facecolor": (
                 to_rgba(self._face_color, self._alpha)
-                if self._face_color != "default" and self._alpha != "default"
-                else "default"
+                if self._face_color != INHERIT and self._alpha != INHERIT
+                else INHERIT
             ),
             "edgecolor": (
                 to_rgba(self._edge_color, 1)
-                if self._edge_color != "default"
+                if self._edge_color != INHERIT
                 else self._edge_color
             ),
             "linewidth": self._line_width,
         }
-        params = {k: v for k, v in params.items() if v != "default"}
+        params = {k: v for k, v in params.items() if v != INHERIT}
         self.handle = Polygon(
             np.array([[0, 2, 2, 3, 3, 1, 1, 0, 0], [0, 0, 1, 1, 2, 2, 3, 3, 0]]).T,
             **params,
@@ -3255,12 +3265,12 @@ class Histogram(Plottable1D):
         params = {
             "facecolor": (
                 to_rgba(self._face_color, self._alpha)
-                if self._face_color != "default" and self._alpha != "default"
-                else "default"
+                if self._face_color != INHERIT and self._alpha != INHERIT
+                else INHERIT
             ),
             "edgecolor": (
                 to_rgba(self._edge_color, 1)
-                if self._edge_color != "default"
+                if self._edge_color != INHERIT
                 else self._edge_color
             ),
             "histtype": self._hist_type,
@@ -3268,7 +3278,7 @@ class Histogram(Plottable1D):
             "density": self._normalize,
             "orientation": self._orientation,
         }
-        params = {k: v for k, v in params.items() if v != "default"}
+        params = {k: v for k, v in params.items() if v != INHERIT}
         axes.hist(
             self._data,
             bins=self._bins,
@@ -3288,7 +3298,7 @@ class Histogram(Plottable1D):
             params = {
                 "color": self._pdf_curve_color,
             }
-            params = {k: v for k, v in params.items() if v != "default"}
+            params = {k: v for k, v in params.items() if v != INHERIT}
 
             # Plots pdf on the y-axis if "orientation" is "horizontal".
             if self._orientation != "vertical":
@@ -3311,7 +3321,7 @@ class Histogram(Plottable1D):
             curve_std_y = normal(self._mean + self._standard_deviation)
             if self._pdf_show_std:
                 params = {}
-                if self._pdf_std_color != "default":
+                if self._pdf_std_color != INHERIT:
                     params["colors"] = [self._pdf_std_color, self._pdf_std_color]
 
                 # Plots std on the y-axis if "orientation" is "horizontal".
@@ -3343,7 +3353,7 @@ class Histogram(Plottable1D):
 
             if self._pdf_show_mean:
                 params = {}
-                if self._pdf_mean_color != "default":
+                if self._pdf_mean_color != INHERIT:
                     params["colors"] = [self._pdf_mean_color]
 
                 # Plots std on the y-axis if "orientation" is "horizontal".

--- a/graphinglib/data_plotting_2d.py
+++ b/graphinglib/data_plotting_2d.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from .inherit import INHERIT, Inherit, is_inherit
+
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Callable, Literal, Optional, Protocol, runtime_checkable
+from typing import Callable, Optional, Protocol, runtime_checkable
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -83,12 +85,12 @@ class Heatmap(Plottable2D):
         y_axis_range: Optional[tuple[float, float]] = None,
         x_mesh: Optional[ArrayLike] = None,
         y_mesh: Optional[ArrayLike] = None,
-        color_map: str | Colormap = "default",
+        color_map: str | Colormap | Inherit = INHERIT,
         color_map_range: Optional[tuple[float, float]] = None,
-        show_color_bar: bool | Literal["default"] = "default",
+        show_color_bar: bool | Inherit = INHERIT,
         alpha: float = 1.0,
-        aspect_ratio: str | float = "default",
-        origin_position: str = "default",
+        aspect_ratio: str | float | Inherit = INHERIT,
+        origin_position: str | Inherit = INHERIT,
         interpolation: str = "none",
         norm: Optional[str | Normalize] = None,
     ) -> None:
@@ -159,12 +161,12 @@ class Heatmap(Plottable2D):
         func: Callable[[ArrayLike, ArrayLike], ArrayLike],
         x_axis_range: tuple[float, float],
         y_axis_range: tuple[float, float],
-        color_map: str | Colormap = "default",
+        color_map: str | Colormap | Inherit = INHERIT,
         color_map_range: Optional[tuple[float, float]] = None,
         show_color_bar: bool = True,
         alpha: float = 1.0,
-        aspect_ratio: str | float = "default",
-        origin_position: str = "default",
+        aspect_ratio: str | float | Inherit = INHERIT,
+        origin_position: str | Inherit = INHERIT,
         interpolation: str = "none",
         number_of_points: tuple[int, int] = (50, 50),
         norm: Optional[str | Normalize] = None,
@@ -241,12 +243,12 @@ class Heatmap(Plottable2D):
         y_axis_range: tuple[float, float],
         grid_interpolation: str = "nearest",
         fill_value: float = np.nan,
-        color_map: str | Colormap = "default",
+        color_map: str | Colormap | Inherit = INHERIT,
         color_map_range: Optional[tuple[float, float]] = None,
         show_color_bar: bool = True,
         alpha: float = 1.0,
-        aspect_ratio: str | float = "default",
-        origin_position: str = "default",
+        aspect_ratio: str | float | Inherit = INHERIT,
+        origin_position: str | Inherit = INHERIT,
         interpolation: str = "none",
         number_of_points: tuple[int, int] = (50, 50),
         norm: Optional[str | Normalize] = None,
@@ -484,7 +486,7 @@ class Heatmap(Plottable2D):
             params["vmax"] = max(self._color_map_range)
         use_pcolormesh = self._x_mesh is not None and self._y_mesh is not None
         if use_pcolormesh:
-            params = {k: v for k, v in params.items() if v != "default"}
+            params = {k: v for k, v in params.items() if v != INHERIT}
             image = axes.pcolormesh(
                 self._x_mesh,
                 self._y_mesh,
@@ -502,7 +504,7 @@ class Heatmap(Plottable2D):
                 }
             )
 
-            params = {k: v for k, v in params.items() if v != "default"}
+            params = {k: v for k, v in params.items() if v != INHERIT}
             image = axes.imshow(
                 self._image,
                 zorder=z_order,
@@ -546,11 +548,11 @@ class VectorField(Plottable2D):
         y_data: ArrayLike,
         u_data: ArrayLike,
         v_data: ArrayLike,
-        arrow_width: float | Literal["default"] = "default",
-        arrow_head_size: float | Literal["default"] = "default",
+        arrow_width: float | Inherit = INHERIT,
+        arrow_head_size: float | Inherit = INHERIT,
         scale: Optional[float] = None,
         make_angles_axes_independent: bool = False,
-        color: str | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
     ) -> None:
         """
         This class implements vector fields.
@@ -600,11 +602,11 @@ class VectorField(Plottable2D):
         y_axis_range: tuple[float, float],
         number_of_arrows_x: int = 10,
         number_of_arrows_y: int = 10,
-        arrow_width: float | Literal["default"] = "default",
-        arrow_head_size: float | Literal["default"] = "default",
+        arrow_width: float | Inherit = INHERIT,
+        arrow_head_size: float | Inherit = INHERIT,
         scale: Optional[float] = None,
         make_angles_axes_independent: bool = False,
-        color: str | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
     ) -> Self:
         """
         Creates a :class:`~graphinglib.data_plotting_2d.VectorField` from a function.
@@ -754,7 +756,7 @@ class VectorField(Plottable2D):
             "scale": 1 / self._scale if self._scale is not None else None,
             "scale_units": "xy",
         }
-        params = {k: v for k, v in params.items() if v != "default"}
+        params = {k: v for k, v in params.items() if v != INHERIT}
         axes.quiver(
             self._x_data,
             self._y_data,
@@ -805,25 +807,25 @@ class Contour(Plottable2D):
     _z_data: ArrayLike
     _x_mesh: ArrayLike
     _y_mesh: ArrayLike
-    _levels: int | Literal["default"] = "default"
-    _color_map: str | Colormap | Literal["default"] = "default"
-    _show_color_bar: bool | Literal["default"] = "default"
-    _filled: bool | Literal["default"] = "default"
-    _alpha: float | Literal["default"] = "default"
-    _line_widths: float | ArrayLike | Literal["default"] = "default"
+    _levels: int | Inherit = INHERIT
+    _color_map: str | Colormap | Inherit = INHERIT
+    _show_color_bar: bool | Inherit = INHERIT
+    _filled: bool | Inherit = INHERIT
+    _alpha: float | Inherit = INHERIT
+    _line_widths: float | ArrayLike | Inherit = INHERIT
 
     def __init__(
         self,
         z_data: ArrayLike,
         x_mesh: Optional[ArrayLike] = None,
         y_mesh: Optional[ArrayLike] = None,
-        levels: int | ArrayLike | Literal["default"] = "default",
-        color_map: str | Colormap | Literal["default"] = "default",
+        levels: int | ArrayLike | Inherit = INHERIT,
+        color_map: str | Colormap | Inherit = INHERIT,
         color_map_range: Optional[tuple[float, float]] = None,
-        show_color_bar: bool | Literal["default"] = "default",
-        filled: bool | Literal["default"] = "default",
-        alpha: float | Literal["default"] = "default",
-        line_widths: float | ArrayLike | Literal["default"] = "default",
+        show_color_bar: bool | Inherit = INHERIT,
+        filled: bool | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
+        line_widths: float | ArrayLike | Inherit = INHERIT,
     ) -> None:
         """
         This class implements contour plots.
@@ -878,13 +880,13 @@ class Contour(Plottable2D):
         func: Callable[[ArrayLike, ArrayLike], ArrayLike],
         x_axis_range: tuple[float, float],
         y_axis_range: tuple[float, float],
-        levels: int | ArrayLike | Literal["default"] = "default",
-        color_map: str | Colormap | Literal["default"] = "default",
+        levels: int | ArrayLike | Inherit = INHERIT,
+        color_map: str | Colormap | Inherit = INHERIT,
         color_map_range: Optional[tuple[float, float]] = None,
-        show_color_bar: bool | Literal["default"] = "default",
-        filled: bool | Literal["default"] = "default",
-        alpha: float | Literal["default"] = "default",
-        line_widths: float | ArrayLike | Literal["default"] = "default",
+        show_color_bar: bool | Inherit = INHERIT,
+        filled: bool | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
+        line_widths: float | ArrayLike | Inherit = INHERIT,
         number_of_points: tuple[int, int] = (500, 500),
     ) -> Self:
         """
@@ -969,11 +971,11 @@ class Contour(Plottable2D):
         self._z_data = np.asarray(z_data)
 
     @property
-    def levels(self) -> int | ArrayLike | Literal["default"]:
+    def levels(self) -> int | ArrayLike | Inherit:
         return self._levels
 
     @levels.setter
-    def levels(self, levels: int | ArrayLike | Literal["default"]) -> None:
+    def levels(self, levels: int | ArrayLike | Inherit) -> None:
         self._levels = levels
 
     @property
@@ -1086,7 +1088,7 @@ class Contour(Plottable2D):
             params["vmax"] = max(self._color_map_range)
 
         params = {
-            k: v for k, v in params.items() if not isinstance(v, str) or v != "default"
+            k: v for k, v in params.items() if not isinstance(v, str) or v != INHERIT
         }
         if self._filled:
             cont = axes.contourf(
@@ -1142,10 +1144,10 @@ class Stream(Plottable2D):
         u_data: ArrayLike,
         v_data: ArrayLike,
         density: float | tuple[float, float] = 1,
-        line_width: float | Literal["default"] = "default",
-        color: str | ArrayLike | Literal["default"] = "default",
-        color_map: str | Colormap | Literal["default"] = "default",
-        arrow_size: float | Literal["default"] = "default",
+        line_width: float | Inherit = INHERIT,
+        color: str | ArrayLike | Inherit = INHERIT,
+        color_map: str | Colormap | Inherit = INHERIT,
+        arrow_size: float | Inherit = INHERIT,
     ) -> None:
         """
         This class implements stream plots.
@@ -1189,10 +1191,10 @@ class Stream(Plottable2D):
         number_of_points_x: int = 30,
         number_of_points_y: int = 30,
         density: float | tuple[float, float] = 1,
-        line_width: float | Literal["default"] = "default",
-        color: str | Literal["default"] = "default",
-        color_map: str | Colormap | Literal["default"] = "default",
-        arrow_size: float | Literal["default"] = "default",
+        line_width: float | Inherit = INHERIT,
+        color: str | Inherit = INHERIT,
+        color_map: str | Colormap | Inherit = INHERIT,
+        arrow_size: float | Inherit = INHERIT,
     ) -> Self:
         """
         Creates a :class:`~graphinglib.data_plotting_2d.Stream` from a function.
@@ -1244,8 +1246,8 @@ class Stream(Plottable2D):
             "cmap": self._color_map,
             "arrowsize": self._arrow_size,
         }
-        params = {k: v for k, v in params.items() if v != "default"}
-        if isinstance(self._color, str) and self._color == "default":
+        params = {k: v for k, v in params.items() if v != INHERIT}
+        if is_inherit(self._color):
             pass
         else:
             params["color"] = self._color

--- a/graphinglib/figure.py
+++ b/graphinglib/figure.py
@@ -1,3 +1,5 @@
+from .inherit import INHERIT, Inherit, is_inherit
+
 from copy import deepcopy
 from shutil import which
 from typing import Literal, Optional
@@ -61,15 +63,15 @@ class Figure:
         self,
         x_label: Optional[str] = None,
         y_label: Optional[str] = None,
-        size: tuple[float, float] | Literal["default"] = "default",
+        size: tuple[float, float] | Inherit = INHERIT,
         title: Optional[str] = None,
         x_lim: Optional[tuple[float, float]] = None,
         y_lim: Optional[tuple[float, float]] = None,
-        log_scale_x: bool | Literal["default"] = "default",
-        log_scale_y: bool | Literal["default"] = "default",
+        log_scale_x: bool | Inherit = INHERIT,
+        log_scale_y: bool | Inherit = INHERIT,
         remove_axes: bool = False,
         aspect_ratio: float | str = "auto",
-        figure_style: str = "default",
+        figure_style: str | Inherit = INHERIT,
     ) -> None:
         """
         This class implements a general figure object.
@@ -122,11 +124,11 @@ class Figure:
         self.aspect_ratio = aspect_ratio
 
     @property
-    def figure_style(self) -> str:
+    def figure_style(self) -> str | Inherit:
         return self._figure_style
 
     @figure_style.setter
-    def figure_style(self, value: str):
+    def figure_style(self, value: str | Inherit):
         self._figure_style = value
 
     @property
@@ -284,7 +286,7 @@ class Figure:
                 self._fill_in_rc_params()
             figure_params_to_reset = self._fill_in_missing_params(self)
         else:
-            if self._figure_style == "default":
+            if self._figure_style == INHERIT:
                 self._figure_style = get_default_style()
             try:
                 file_loader = FileLoader(self._figure_style)
@@ -534,7 +536,7 @@ class Figure:
         while tries < 2:
             try:
                 for property, value in vars(element).items():
-                    if (type(value) is str) and (value == "default"):
+                    if is_inherit(value):
                         params_to_reset.append(property)
                         default_value = self._default_params[object_type][property]
                         setattr(element, property, default_value)
@@ -561,7 +563,7 @@ class Figure:
             setattr(
                 element,
                 param,
-                "default",
+                INHERIT,
             )
 
     def set_rc_params(
@@ -771,10 +773,10 @@ class Figure:
         visible_y: bool = True,
         which_x: Literal["both", "major", "minor"] = "both",
         which_y: Literal["both", "major", "minor"] = "both",
-        color: str = "default",
-        alpha: float | Literal["default"] = "default",
-        line_style: str = "default",
-        line_width: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
     ) -> None:
         """
         Sets the grid parameters for the figure.
@@ -815,7 +817,7 @@ class Figure:
             "grid.linestyle": line_style,
             "grid.linewidth": line_width,
         }
-        rc_params_dict = {k: v for k, v in rc_params_dict.items() if v != "default"}
+        rc_params_dict = {k: v for k, v in rc_params_dict.items() if v != INHERIT}
         self.set_rc_params(rc_params_dict)
 
     def create_twin_axis(
@@ -945,14 +947,14 @@ class TwinAxis:
         fig_axes: plt.Axes,
         is_matplotlib_style: bool = False,
         default_params: dict = None,
-        figure_style: str = "default",
+        figure_style: str | Inherit = INHERIT,
     ):
         """
         Prepares the :class:`~graphinglib.figure.TwinAxis` to be displayed.
         """
         self._default_params = default_params
         self._figure_style = (
-            figure_style if figure_style != "default" else get_default_style()
+            figure_style if figure_style != INHERIT else get_default_style()
         )
         if self._is_y:
             self._axes = fig_axes.twinx()
@@ -1128,7 +1130,7 @@ class TwinAxis:
         while tries < 2:
             try:
                 for property, value in vars(element).items():
-                    if (type(value) is str) and (value == "default"):
+                    if is_inherit(value):
                         params_to_reset.append(property)
                         default_value = self._default_params[object_type][property]
                         if default_value == "same as curve":
@@ -1164,5 +1166,5 @@ class TwinAxis:
             setattr(
                 element,
                 param,
-                "default",
+                INHERIT,
             )

--- a/graphinglib/fits.py
+++ b/graphinglib/fits.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from .inherit import INHERIT, Inherit
+
 from copy import deepcopy
 from functools import partial
-from typing import Callable, Literal, Optional
+from typing import Callable, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -48,10 +50,10 @@ class GeneralFit(Curve):
         self,
         curve_to_be_fit: Curve | Scatter,
         label: Optional[str] = None,
-        color: str = "default",
-        line_width: int | Literal["default"] = "default",
-        line_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: int | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
     ) -> None:
         """
         Parameters
@@ -135,12 +137,12 @@ class GeneralFit(Curve):
         self,
         x: float,
         label: str | None = None,
-        face_color: str = "default",
-        edge_color: str = "default",
-        marker_size: float | Literal["default"] = "default",
-        marker_style: str = "default",
-        line_width: float | Literal["default"] = "default",
-        alpha: float | Literal["default"] = "default",
+        face_color: str | Inherit = INHERIT,
+        edge_color: str | Inherit = INHERIT,
+        marker_size: float | Inherit = INHERIT,
+        marker_style: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
     ) -> Point:
         """
         Gets the point on the curve at a given x value.
@@ -196,12 +198,12 @@ class GeneralFit(Curve):
         y: float,
         interpolation_kind: str = "linear",
         label: str | None = None,
-        face_color: str = "default",
-        edge_color: str = "default",
-        marker_size: float | Literal["default"] = "default",
-        marker_style: str = "default",
-        line_width: float | Literal["default"] = "default",
-        alpha: float | Literal["default"] = "default",
+        face_color: str | Inherit = INHERIT,
+        edge_color: str | Inherit = INHERIT,
+        marker_size: float | Inherit = INHERIT,
+        marker_style: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
     ) -> list[Point]:
         """
         Creates the Points on the curve at a given y value.
@@ -267,7 +269,7 @@ class GeneralFit(Curve):
             "linestyle": self._line_style,
             "alpha": self._alpha,
         }
-        params = {key: value for key, value in params.items() if value != "default"}
+        params = {key: value for key, value in params.items() if value != INHERIT}
         (self.handle,) = axes.plot(
             self._x_data,
             self._y_data,
@@ -287,7 +289,7 @@ class GeneralFit(Curve):
                 "linestyle": self._res_line_style,
                 "alpha": self._alpha,
             }
-            params = {key: value for key, value in params.items() if value != "default"}
+            params = {key: value for key, value in params.items() if value != INHERIT}
             axes.plot(
                 self._x_data,
                 y_fit_minus_std,
@@ -306,7 +308,7 @@ class GeneralFit(Curve):
                 kwargs["color"] = self._fill_between_color
             else:
                 kwargs["color"] = self.handle[0].get_color()
-            params = {key: value for key, value in kwargs.items() if value != "default"}
+            params = {key: value for key, value in kwargs.items() if value != INHERIT}
             axes.fill_between(
                 self._x_data,
                 self._y_data,
@@ -321,9 +323,9 @@ class GeneralFit(Curve):
     def show_residual_curves(
         self,
         sigma_multiplier: float = 1,
-        color: str = "default",
-        line_width: float | Literal["default"] = "default",
-        line_style: str = "default",
+        color: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
     ) -> None:
         """
         Displays two curves ``"sigma_multiplier"`` standard deviations above and below the fit curve.
@@ -426,10 +428,10 @@ class FitFromPolynomial(GeneralFit):
         curve_to_be_fit: Curve | Scatter,
         degree: int,
         label: Optional[str] = None,
-        color: str = "default",
-        line_width: int | Literal["default"] = "default",
-        line_style: int | Literal["default"] = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: int | Inherit = INHERIT,
+        line_style: int | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
     ) -> None:
         """
         Creates a curve fit (continuous :class:`~graphinglib.data_plotting_1d.Curve`) from an existing curve object using a polynomial fit.
@@ -625,10 +627,10 @@ class FitFromSine(GeneralFit):
         curve_to_be_fit: Curve | Scatter,
         label: Optional[str] = None,
         guesses: Optional[ArrayLike] = None,
-        color: str = "default",
-        line_width: str = "default",
-        line_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: str | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         max_iterations: int = 10000,
     ) -> None:
         """
@@ -862,10 +864,10 @@ class FitFromExponential(GeneralFit):
         curve_to_be_fit: Curve | Scatter,
         label: Optional[str] = None,
         guesses: Optional[ArrayLike] = None,
-        color: str = "default",
-        line_width: int | Literal["default"] = "default",
-        line_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: int | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         max_iterations: int = 10000,
     ) -> None:
         """
@@ -1058,10 +1060,10 @@ class FitFromGaussian(GeneralFit):
         curve_to_be_fit: Curve | Scatter,
         label: Optional[str] = None,
         guesses: Optional[ArrayLike] = None,
-        color: str = "default",
-        line_width: int | Literal["default"] = "default",
-        line_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: int | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         max_iterations: int = 10000,
     ) -> None:
         """
@@ -1267,10 +1269,10 @@ class FitFromSquareRoot(GeneralFit):
         curve_to_be_fit: Curve | Scatter,
         label: Optional[str] = None,
         guesses: Optional[ArrayLike] = None,
-        color: str = "default",
-        line_width: int | Literal["default"] = "default",
-        line_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: int | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         max_iterations: int = 10000,
     ) -> None:
         """
@@ -1456,10 +1458,10 @@ class FitFromLog(GeneralFit):
         label: Optional[str] = None,
         log_base: float = np.e,
         guesses: Optional[ArrayLike] = None,
-        color: str = "default",
-        line_width: int | Literal["default"] = "default",
-        line_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: int | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         max_iterations: int = 10000,
     ) -> None:
         """
@@ -1649,10 +1651,10 @@ class FitFromFunction(GeneralFit):
         curve_to_be_fit: Curve | Scatter,
         label: Optional[str] = None,
         guesses: Optional[ArrayLike] = None,
-        color: str = "default",
-        line_width: int | Literal["default"] = "default",
-        line_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: int | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         max_iterations: int = 10000,
     ):
         """
@@ -1821,10 +1823,10 @@ class FitFromFOTF(GeneralFit):
         curve_to_be_fit: Curve | Scatter,
         label: Optional[str] = None,
         guesses: Optional[ArrayLike] = None,
-        color: str = "default",
-        line_width: int | Literal["default"] = "default",
-        line_style: str = "default",
-        alpha: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        line_width: int | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         max_iterations: int = 10000,
     ) -> None:
         """

--- a/graphinglib/graph_elements.py
+++ b/graphinglib/graph_elements.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .inherit import INHERIT, Inherit
+
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Literal, Optional, Protocol, runtime_checkable
@@ -126,18 +128,18 @@ class Hlines(Plottable):
         x_min: Optional[ArrayLike] = None,
         x_max: Optional[ArrayLike] = None,
         label: Optional[str] = None,
-        colors: list[str] | str = "default",
-        line_widths: list[float] | float = "default",
-        line_styles: list[str] | str = "default",
-        alpha: float | Literal["default"] = "default",
+        colors: list[str] | str | Inherit = INHERIT,
+        line_widths: list[float] | float | Inherit = INHERIT,
+        line_styles: list[str] | str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
     ) -> None:
         self._in_init = True
         self._y = None
         self._x_min = None
         self._x_max = None
-        self._colors = "default"
-        self._line_widths = "default"
-        self._line_styles = "default"
+        self._colors = INHERIT
+        self._line_widths = INHERIT
+        self._line_styles = INHERIT
         self.y = y
         self.x_min = x_min
         self.x_max = x_max
@@ -272,7 +274,7 @@ class Hlines(Plottable):
             self._validate_state()
 
     @property
-    def alpha(self) -> float | Literal["default"]:
+    def alpha(self) -> float | Inherit:
         return self._alpha
 
     def copy(self) -> Self:
@@ -294,7 +296,7 @@ class Hlines(Plottable):
                     "linewidths": self._line_widths,
                     "alpha": self._alpha,
                 }
-                params = {k: v for k, v in params.items() if v != "default"}
+                params = {k: v for k, v in params.items() if v != INHERIT}
                 axes.hlines(
                     self._y,
                     self._x_min,
@@ -310,7 +312,7 @@ class Hlines(Plottable):
                     "linewidth": self._line_widths,
                     "alpha": self._alpha,
                 }
-                params = {k: v for k, v in params.items() if v != "default"}
+                params = {k: v for k, v in params.items() if v != INHERIT}
                 for i in range(len(self._y)):
                     axes.axhline(
                         self._y[i],
@@ -333,7 +335,7 @@ class Hlines(Plottable):
                     "linewidths": self._line_widths,
                     "alpha": self._alpha,
                 }
-                params = {k: v for k, v in params.items() if v != "default"}
+                params = {k: v for k, v in params.items() if v != INHERIT}
                 axes.hlines(
                     self._y,
                     self._x_min,
@@ -349,7 +351,7 @@ class Hlines(Plottable):
                     "linewidth": self._line_widths,
                     "alpha": self._alpha,
                 }
-                params = {k: v for k, v in params.items() if v != "default"}
+                params = {k: v for k, v in params.items() if v != INHERIT}
                 axes.axhline(self._y, zorder=z_order, **params)
                 params.pop("linewidth")
             if isinstance(self._y, (int, float)):
@@ -400,18 +402,18 @@ class Vlines(Plottable):
         y_min: Optional[ArrayLike] = None,
         y_max: Optional[ArrayLike] = None,
         label: Optional[str] = None,
-        colors: list[str] | str = "default",
-        line_widths: list[float] | float = "default",
-        line_styles: list[str] | str = "default",
-        alpha: float | Literal["default"] = "default",
+        colors: list[str] | str | Inherit = INHERIT,
+        line_widths: list[float] | float | Inherit = INHERIT,
+        line_styles: list[str] | str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
     ) -> None:
         self._in_init = True
         self._x = None
         self._y_min = None
         self._y_max = None
-        self._colors = "default"
-        self._line_styles = "default"
-        self._line_widths = "default"
+        self._colors = INHERIT
+        self._line_styles = INHERIT
+        self._line_widths = INHERIT
         self.x = x
         self.y_min = y_min
         self.y_max = y_max
@@ -537,11 +539,11 @@ class Vlines(Plottable):
             self._validate_state()
 
     @property
-    def alpha(self) -> float | Literal["default"]:
+    def alpha(self) -> float | Inherit:
         return self._alpha
 
     @alpha.setter
-    def alpha(self, alpha: float | Literal["default"]) -> None:
+    def alpha(self, alpha: float | Inherit) -> None:
         self._alpha = alpha
 
     def copy(self) -> Self:
@@ -563,7 +565,7 @@ class Vlines(Plottable):
                     "linewidths": self._line_widths,
                     "alpha": self._alpha,
                 }
-                params = {k: v for k, v in params.items() if v != "default"}
+                params = {k: v for k, v in params.items() if v != INHERIT}
                 axes.vlines(
                     self._x,
                     self._y_min,
@@ -579,7 +581,7 @@ class Vlines(Plottable):
                     "linewidth": self._line_widths,
                     "alpha": self._alpha,
                 }
-                params = {k: v for k, v in params.items() if v != "default"}
+                params = {k: v for k, v in params.items() if v != INHERIT}
                 for i in range(len(self._x)):
                     axes.axvline(
                         self._x[i],
@@ -602,7 +604,7 @@ class Vlines(Plottable):
                     "linewidths": self._line_widths,
                     "alpha": self._alpha,
                 }
-                params = {k: v for k, v in params.items() if v != "default"}
+                params = {k: v for k, v in params.items() if v != INHERIT}
                 axes.vlines(
                     self._x,
                     self._y_min,
@@ -618,7 +620,7 @@ class Vlines(Plottable):
                     "linewidth": self._line_widths,
                     "alpha": self._alpha,
                 }
-                params = {k: v for k, v in params.items() if v != "default"}
+                params = {k: v for k, v in params.items() if v != INHERIT}
                 axes.axvline(self._x, zorder=z_order, **params)
                 params.pop("linewidth")
             if isinstance(self._x, (int, float)):
@@ -679,14 +681,14 @@ class Point(Plottable):
         x: float,
         y: float,
         label: Optional[str] = None,
-        face_color: Optional[str] = "default",
-        edge_color: Optional[str] = "default",
-        marker_size: float | Literal["default"] = "default",
-        marker_style: str = "default",
-        edge_width: float | Literal["default"] = "default",
-        alpha: float | Literal["default"] = "default",
+        face_color: Optional[str] | Inherit = INHERIT,
+        edge_color: Optional[str] | Inherit = INHERIT,
+        marker_size: float | Inherit = INHERIT,
+        marker_style: str | Inherit = INHERIT,
+        edge_width: float | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         font_size: int | Literal["same as figure"] = "same as figure",
-        text_color: str = "default",
+        text_color: str | Inherit = INHERIT,
         h_align: str = "left",
         v_align: str = "bottom",
     ) -> None:
@@ -796,11 +798,11 @@ class Point(Plottable):
         self._edge_color = edge_color
 
     @property
-    def marker_size(self) -> float | Literal["default"]:
+    def marker_size(self) -> float | Inherit:
         return self._marker_size
 
     @marker_size.setter
-    def marker_size(self, marker_size: float | Literal["default"]) -> None:
+    def marker_size(self, marker_size: float | Inherit) -> None:
         self._marker_size = marker_size
 
     @property
@@ -812,19 +814,19 @@ class Point(Plottable):
         self._marker_style = marker_style
 
     @property
-    def edge_width(self) -> float | Literal["default"]:
+    def edge_width(self) -> float | Inherit:
         return self._edge_width
 
     @edge_width.setter
-    def edge_width(self, edge_width: float | Literal["default"]) -> None:
+    def edge_width(self, edge_width: float | Inherit) -> None:
         self._edge_width = edge_width
 
     @property
-    def alpha(self) -> float | Literal["default"]:
+    def alpha(self) -> float | Inherit:
         return self._alpha
 
     @alpha.setter
-    def alpha(self, alpha: float | Literal["default"]) -> None:
+    def alpha(self, alpha: float | Inherit) -> None:
         self._alpha = alpha
 
     @property
@@ -913,7 +915,7 @@ class Point(Plottable):
             "linewidths": self._edge_width,
             "alpha": self._alpha,
         }
-        params = {k: v for k, v in params.items() if v != "default"}
+        params = {k: v for k, v in params.items() if v != INHERIT}
         axes.scatter(
             self._x,
             self._y,
@@ -934,7 +936,7 @@ class Point(Plottable):
             "horizontalalignment": self._h_align,
             "verticalalignment": self._v_align,
         }
-        params = {k: v for k, v in params.items() if v != "default"}
+        params = {k: v for k, v in params.items() if v != INHERIT}
         axes.annotate(
             point_label,
             (self._x, self._y),
@@ -967,7 +969,7 @@ class Point(Plottable):
                 "horizontalalignment": self._h_align,
                 "verticalalignment": self._v_align,
             }
-            params = {k: v for k, v in params.items() if v != "default"}
+            params = {k: v for k, v in params.items() if v != INHERIT}
             axes.annotate(
                 point_label,
                 (self._x, self._y),
@@ -1021,11 +1023,11 @@ class Text(Plottable):
     _x: float
     _y: float
     _text: str
-    _color: str = "default"
+    _color: str | Inherit = INHERIT
     _font_size: float | Literal["same as figure"] = "same as figure"
-    _alpha: float | Literal["default"] = "default"
-    _h_align: str = "default"
-    _v_align: str = "default"
+    _alpha: float | Inherit = INHERIT
+    _h_align: str | Inherit = INHERIT
+    _v_align: str | Inherit = INHERIT
     _rotation: float = 0.0
     _highlight_color: Optional[str] = None
     _highlight_alpha: float = 1.0
@@ -1037,11 +1039,11 @@ class Text(Plottable):
         x: float,
         y: float,
         text: str,
-        color: str = "default",
+        color: str | Inherit = INHERIT,
         font_size: float | Literal["same as figure"] = "same as figure",
-        alpha: float | Literal["default"] = "default",
-        h_align: str = "default",
-        v_align: str = "default",
+        alpha: float | Inherit = INHERIT,
+        h_align: str | Inherit = INHERIT,
+        v_align: str | Inherit = INHERIT,
         rotation: float = 0.0,
         highlight_color: Optional[str] = None,
         highlight_alpha: float = 1.0,
@@ -1141,11 +1143,11 @@ class Text(Plottable):
         self._font_size = font_size
 
     @property
-    def alpha(self) -> float | Literal["default"]:
+    def alpha(self) -> float | Inherit:
         return self._alpha
 
     @alpha.setter
-    def alpha(self, alpha: float | Literal["default"]) -> None:
+    def alpha(self, alpha: float | Inherit) -> None:
         self._alpha = alpha
 
     @property
@@ -1280,7 +1282,7 @@ class Text(Plottable):
             }
             params["bbox"] = bbox_dict
 
-        params = {k: v for k, v in params.items() if v != "default"}
+        params = {k: v for k, v in params.items() if v != INHERIT}
         target.text(
             self._x,
             self._y,
@@ -1296,8 +1298,8 @@ class Text(Plottable):
                 "horizontalalignment": self._h_align,
                 "verticalalignment": self._v_align,
             }
-            params = {k: v for k, v in params.items() if v != "default"}
-            if self._color != "default":
+            params = {k: v for k, v in params.items() if v != INHERIT}
+            if self._color != INHERIT:
                 self._arrow_properties["color"] = self._color
                 params["arrowprops"] = self._arrow_properties
             target.annotate(
@@ -1372,18 +1374,18 @@ class Table(Plottable):
     def __init__(
         self,
         cell_text: list[str],
-        cell_colors: ArrayLike | str = "default",
-        cell_align: str = "default",
+        cell_colors: ArrayLike | str | Inherit = INHERIT,
+        cell_align: str | Inherit = INHERIT,
         col_labels: Optional[list[str]] = None,
         col_widths: Optional[list[float]] = None,
-        col_align: str = "default",
-        col_colors: ArrayLike | str = "default",
+        col_align: str | Inherit = INHERIT,
+        col_colors: ArrayLike | str | Inherit = INHERIT,
         row_labels: Optional[list[str]] = None,
-        row_align: str = "default",
-        row_colors: ArrayLike | str = "default",
-        edge_width: float | Literal["default"] = "default",
-        edge_color: str = "default",
-        text_color: str = "default",
+        row_align: str | Inherit = INHERIT,
+        row_colors: ArrayLike | str | Inherit = INHERIT,
+        edge_width: float | Inherit = INHERIT,
+        edge_color: str | Inherit = INHERIT,
+        text_color: str | Inherit = INHERIT,
         scaling: tuple[float, float] = (1.0, 1.5),
         location: str = "best",
     ) -> None:
@@ -1602,7 +1604,7 @@ class Table(Plottable):
             "colLoc": self._col_align,
             "rowLoc": self._row_align,
         }
-        params = {k: v for k, v in params.items() if v != "default"}
+        params = {k: v for k, v in params.items() if v != INHERIT}
 
         # Set colors to correct shape if they are strings
         if isinstance(self._cell_colors, str):

--- a/graphinglib/inherit.py
+++ b/graphinglib/inherit.py
@@ -1,0 +1,23 @@
+from typing import TypeGuard
+
+
+class Inherit:
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "Inherit"
+
+    __str__ = __repr__
+
+    def __copy__(self) -> "Inherit":
+        return self
+
+    def __deepcopy__(self, memo: dict[int, object]) -> "Inherit":
+        return self
+
+
+INHERIT = Inherit()
+
+
+def is_inherit(value: object) -> TypeGuard[Inherit]:
+    return value is INHERIT

--- a/graphinglib/multifigure.py
+++ b/graphinglib/multifigure.py
@@ -1,7 +1,9 @@
+from .inherit import INHERIT, Inherit, is_inherit
+
 from copy import deepcopy
 from shutil import which
 from string import ascii_lowercase
-from typing import Literal, Optional
+from typing import Optional
 
 import matplotlib.pyplot as plt
 from matplotlib import rcParamsDefault
@@ -70,11 +72,11 @@ class MultiFigure:
         self,
         num_rows: int,
         num_cols: int,
-        size: tuple[float, float] | Literal["default"] = "default",
+        size: tuple[float, float] | Inherit = INHERIT,
         title: Optional[str] = None,
         reference_labels: bool = True,
         reflabel_loc: str = "outside",
-        figure_style: str = "default",
+        figure_style: str | Inherit = INHERIT,
     ) -> None:
         """
         This class implements the "canvas" on which multiple plots are displayed.
@@ -160,19 +162,19 @@ class MultiFigure:
         self._reflabel_loc = reflabel_loc
 
     @property
-    def figure_style(self) -> str:
+    def figure_style(self) -> str | Inherit:
         return self._figure_style
 
     @figure_style.setter
-    def figure_style(self, figure_style: str) -> None:
+    def figure_style(self, figure_style: str | Inherit) -> None:
         self._figure_style = figure_style
 
     @property
-    def size(self) -> tuple[float, float] | Literal["default"]:
+    def size(self) -> tuple[float, float] | Inherit:
         return self._size
 
     @size.setter
-    def size(self, size: tuple[float, float] | Literal["default"]) -> None:
+    def size(self, size: tuple[float, float] | Inherit) -> None:
         self._size = size
 
     def copy(self) -> Self:
@@ -202,11 +204,11 @@ class MultiFigure:
     def from_row(
         cls,
         figures: list[Figure],
-        size: tuple[float, float] | Literal["default"] = "default",
+        size: tuple[float, float] | Inherit = INHERIT,
         title: Optional[str] = None,
         reference_labels: bool = True,
         reflabel_loc: str = "outside",
-        figure_style: str = "default",
+        figure_style: str | Inherit = INHERIT,
     ) -> Self:
         """Creates a MultiFigure with the specified :class:`~graphinglib.figure.Figure` objects in a horizontal configuration.
 
@@ -251,11 +253,11 @@ class MultiFigure:
     def from_stack(
         cls,
         figures: list[Figure],
-        size: tuple[float, float] | Literal["default"] = "default",
+        size: tuple[float, float] | Inherit = INHERIT,
         title: Optional[str] = None,
         reference_labels: bool = True,
         reflabel_loc: str = "outside",
-        figure_style: str = "default",
+        figure_style: str | Inherit = INHERIT,
     ) -> Self:
         """Creates a MultiFigure with the specified :class:`~graphinglib.figure.Figure` objects in a vertical configuration.
 
@@ -301,11 +303,11 @@ class MultiFigure:
         cls,
         figures: list[Figure],
         dimensions: tuple[int, int],
-        size: tuple[float, float] | Literal["default"] = "default",
+        size: tuple[float, float] | Inherit = INHERIT,
         title: Optional[str] = None,
         reference_labels: bool = True,
         reflabel_loc: str = "outside",
-        figure_style: str = "default",
+        figure_style: str | Inherit = INHERIT,
     ) -> Self:
         """Creates a MultiFigure with the specified :class:`~graphinglib.figure.Figure` objects in a grid configuration.
 
@@ -486,7 +488,7 @@ class MultiFigure:
         """
         Prepares the :class:`~graphinglib.multifigure.MultiFigure` to be displayed.
         """
-        if self._figure_style == "default":
+        if self._figure_style == INHERIT:
             self._figure_style = get_default_style()
         try:
             file_loader = FileLoader(self._figure_style)
@@ -617,7 +619,7 @@ class MultiFigure:
         params_to_reset = []
         object_type = type(element).__name__
         for property, value in vars(element).items():
-            if (type(value) is str) and (value == "default"):
+            if is_inherit(value):
                 params_to_reset.append(property)
                 if self._default_params[object_type][property] == "same as curve":
                     element.__dict__["_errorbars_color"] = self._default_params[
@@ -646,7 +648,7 @@ class MultiFigure:
         Resets the parameters that were set to default in the _fill_in_missing_params method.
         """
         for param in params_to_reset:
-            setattr(element, param, "default")
+            setattr(element, param, INHERIT)
 
     def _fill_in_rc_params(self, is_matplotlib_style: bool = False) -> None:
         """

--- a/graphinglib/shapes.py
+++ b/graphinglib/shapes.py
@@ -1,3 +1,5 @@
+from .inherit import INHERIT, Inherit
+
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Literal, Optional
@@ -38,7 +40,7 @@ class Arrow(Plottable):
     head_size : float, optional
         Scales the size of the arrow head.
         Default depends on the ``figure_style`` configuration.
-    style : ``Literal["->", "-|>", "-[", "]->", "simple", "fancy", "wedge", "default"]``, optional
+    style : ``Literal["->", "-|>", "-[", "]->", "simple", "fancy", "wedge"] | Inherit``, optional
         The style of the arrow. For a visual explanation of all available styles, see the gallery
         `Arrow Styles <https://graphinglib.org/latest/examples/arrow_styles.html>`_ example.
         Default depends on the ``figure_style`` configuration.
@@ -61,14 +63,13 @@ class Arrow(Plottable):
         self,
         pointA: tuple[float, float],
         pointB: tuple[float, float],
-        color: str = "default",
-        width: float | Literal["default"] = "default",
-        head_size: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        width: float | Inherit = INHERIT,
+        head_size: float | Inherit = INHERIT,
         shrink: float = 0,
-        style: Literal[
-            "->", "-|>", "-[", "]->", "simple", "fancy", "wedge", "default"
-        ] = "default",
-        alpha: float | Literal["default"] = "default",
+        style: Literal["->", "-|>", "-[", "]->", "simple", "fancy", "wedge"]
+        | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
         two_sided: bool = False,
     ):
         """This class implements an arrow object.
@@ -86,7 +87,7 @@ class Arrow(Plottable):
         head_size : float, optional
             Scales the size of the arrow head.
             Default depends on the ``figure_style`` configuration.
-        style : ``Literal["->", "-|>", "-[", "]->", "simple", "fancy", "wedge", "default"]``, optional
+        style : ``Literal["->", "-|>", "-[", "]->", "simple", "fancy", "wedge"] | Inherit``, optional
             The style of the arrow. For a visual explanation of all available styles, see the gallery
             `Arrow Styles <https://graphinglib.org/latest/examples/arrow_styles.html>`_ example.
             Default depends on the ``figure_style`` configuration.
@@ -173,11 +174,11 @@ class Arrow(Plottable):
             "simple",
             "fancy",
             "wedge",
-            "default",
+            INHERIT,
         ]:
             raise ValueError(
                 "Invalid head style. Valid options are: '->', '-|>', '-[', ']->', 'simple', 'fancy', "
-                "'wedge', 'default'."
+                "'wedge', or INHERIT."
             )
         self._style = value
 
@@ -234,7 +235,7 @@ class Arrow(Plottable):
         else:
             style = self._style
 
-        if self._head_size != "default":
+        if self._head_size != INHERIT:
             head_length, head_width = self._head_size * 0.4, self._head_size * 0.2
 
             # Set specific arrow properties
@@ -262,7 +263,7 @@ class Arrow(Plottable):
             "linewidth": self._width,
             "alpha": self._alpha,
         }
-        props = {k: v for k, v in props.items() if v != "default"}
+        props = {k: v for k, v in props.items() if v != INHERIT}
         if self._shrink != 0:
             shrinkPointA, shrinkPointB = self._shrink_points()
             axes.annotate(
@@ -311,21 +312,21 @@ class Line(Plottable):
 
     _pointA: tuple[float, float]
     _pointB: tuple[float, float]
-    _color: str = "default"
-    _width: float | Literal["default"] = "default"
+    _color: str | Inherit = INHERIT
+    _width: float | Inherit = INHERIT
     _capped_line: bool = False
-    _cap_width: float | Literal["default"] = "default"
-    _alpha: float | Literal["default"] = "default"
+    _cap_width: float | Inherit = INHERIT
+    _alpha: float | Inherit = INHERIT
 
     def __init__(
         self,
         pointA: tuple[float, float],
         pointB: tuple[float, float],
-        color: str = "default",
-        width: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        width: float | Inherit = INHERIT,
         capped_line: bool = False,
-        cap_width: float | Literal["default"] = "default",
-        alpha: float | Literal["default"] = "default",
+        cap_width: float | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
     ):
         self._pointA = pointA
         self._pointB = pointB
@@ -408,7 +409,7 @@ class Line(Plottable):
             "linewidth": self._width,
             "alpha": self._alpha,
         }
-        props = {k: v for k, v in props.items() if v != "default"}
+        props = {k: v for k, v in props.items() if v != INHERIT}
         axes.annotate(
             "",
             self._pointA,
@@ -445,12 +446,12 @@ class Polygon(Plottable):
     def __init__(
         self,
         vertices: list[tuple[float, float]],
-        fill: bool = "default",
-        edge_color: str = "default",
-        fill_color: str = "default",
-        line_width: float | Literal["default"] = "default",
-        line_style: str = "default",
-        fill_alpha: float | Literal["default"] = "default",
+        fill: bool | Inherit = INHERIT,
+        edge_color: str | Inherit = INHERIT,
+        fill_color: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        fill_alpha: float | Inherit = INHERIT,
     ):
         self._fill = fill
         self._edge_color = edge_color
@@ -860,7 +861,7 @@ class Polygon(Plottable):
             }
             if self._fill_color is not None:
                 params["facecolor"] = self._fill_color
-            params = {k: v for k, v in params.items() if v != "default"}
+            params = {k: v for k, v in params.items() if v != INHERIT}
             polygon_fill = MPLPolygon(self.vertices, **params)
             axes.add_patch(polygon_fill)
         # Create a polygon patch for the edge
@@ -872,7 +873,7 @@ class Polygon(Plottable):
                 "edgecolor": self._edge_color,
                 "zorder": z_order,
             }
-            params = {k: v for k, v in params.items() if v != "default"}
+            params = {k: v for k, v in params.items() if v != INHERIT}
             polygon_edge = MPLPolygon(self.vertices, **params)
             axes.add_patch(polygon_edge)
 
@@ -917,12 +918,12 @@ class Circle(Polygon):
         x_center: float,
         y_center: float,
         radius: float,
-        fill: bool = "default",
-        fill_color: str = "default",
-        edge_color: str = "default",
-        line_width: float | Literal["default"] = "default",
-        line_style: str = "default",
-        fill_alpha: float | Literal["default"] = "default",
+        fill: bool | Inherit = INHERIT,
+        fill_color: str | Inherit = INHERIT,
+        edge_color: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        fill_alpha: float | Inherit = INHERIT,
         number_of_points: int = 100,
     ):
         self.number_of_points = number_of_points
@@ -1039,12 +1040,12 @@ class Ellipse(Polygon):
         x_radius: float,
         y_radius: float,
         angle: float = 0,
-        fill: bool = "default",
-        fill_color: str = "default",
-        edge_color: str = "default",
-        line_width: float | Literal["default"] = "default",
-        line_style: str = "default",
-        fill_alpha: float | Literal["default"] = "default",
+        fill: bool | Inherit = INHERIT,
+        fill_color: str | Inherit = INHERIT,
+        edge_color: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        fill_alpha: float | Inherit = INHERIT,
         number_of_points: int = 100,
     ):
         self.number_of_points = number_of_points
@@ -1214,12 +1215,12 @@ class Rectangle(Polygon):
         y_bottom_left: float,
         width: float,
         height: float,
-        fill: bool = "default",
-        fill_color: str = "default",
-        edge_color: str = "default",
-        line_width: float | Literal["default"] = "default",
-        line_style: str = "default",
-        fill_alpha: float | Literal["default"] = "default",
+        fill: bool | Inherit = INHERIT,
+        fill_color: str | Inherit = INHERIT,
+        edge_color: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        fill_alpha: float | Inherit = INHERIT,
     ):
         self._fill = fill
         self._fill_color = fill_color
@@ -1325,12 +1326,12 @@ class Rectangle(Polygon):
         y: float,
         width: float,
         height: float,
-        fill: bool = "default",
-        fill_color: str = "default",
-        edge_color: str = "default",
-        line_width: float | Literal["default"] = "default",
-        line_style: str = "default",
-        fill_alpha: float | Literal["default"] = "default",
+        fill: bool | Inherit = INHERIT,
+        fill_color: str | Inherit = INHERIT,
+        edge_color: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        fill_alpha: float | Inherit = INHERIT,
     ) -> Self:
         """Creates a :class:`~graphinglib.shapes.Rectangle` from its center point, width and height.
 

--- a/graphinglib/smart_figure.py
+++ b/graphinglib/smart_figure.py
@@ -1,5 +1,7 @@
 from __future__ import annotations as _annotations_
 
+from .inherit import INHERIT, Inherit, is_inherit
+
 from collections import OrderedDict
 from copy import deepcopy
 from logging import warning
@@ -255,7 +257,7 @@ class SmartFigure:
         num_cols: int = 1,
         x_label: str | None = None,
         y_label: str | None = None,
-        size: tuple[float, float] | Literal["default"] = "default",
+        size: tuple[float, float] | Inherit = INHERIT,
         title: str | None = None,
         x_lim: ListOrItem[tuple[float, float] | None] = None,
         y_lim: ListOrItem[tuple[float, float] | None] = None,
@@ -289,7 +291,7 @@ class SmartFigure:
         show_legend: ListOrItem[bool] = True,
         twin_x_axis: SmartTwinAxis | None = None,
         twin_y_axis: SmartTwinAxis | None = None,
-        figure_style: str = "default",
+        figure_style: str | Inherit = INHERIT,
         elements: Plottable
         | Iterable[Plottable | SmartFigure | None]
         | Iterable[Iterable[Plottable | None]] = [],
@@ -458,12 +460,12 @@ class SmartFigure:
         self._y_label = value
 
     @property
-    def size(self) -> tuple[float, float] | Literal["default"]:
+    def size(self) -> tuple[float, float] | Inherit:
         return self._size
 
     @size.setter
-    def size(self, value: tuple[float, float] | Literal["default"]):
-        if not isinstance(value, tuple) and value != "default":
+    def size(self, value: tuple[float, float] | Inherit):
+        if not isinstance(value, tuple) and value != INHERIT:
             raise TypeError("size must be a tuple or 'default'.")
         if isinstance(value, tuple) and len(value) != 2:
             raise ValueError("size must be a tuple of length 2.")
@@ -895,14 +897,14 @@ class SmartFigure:
         self._twin_y_axis = value
 
     @property
-    def figure_style(self) -> str:
+    def figure_style(self) -> str | Inherit:
         return self._figure_style
 
     @figure_style.setter
-    def figure_style(self, value: str) -> None:
-        if not isinstance(value, str):
-            raise TypeError("figure_style must be a string.")
-        available_styles = ["default", "matplotlib"] + get_styles(matplotlib=True)
+    def figure_style(self, value: str | Inherit) -> None:
+        if not isinstance(value, str) and not is_inherit(value):
+            raise TypeError("figure_style must be a string or INHERIT.")
+        available_styles = [INHERIT, "matplotlib"] + get_styles(matplotlib=True)
         if value not in available_styles:
             raise ValueError(f"figure_style must be one of {available_styles}.")
         self._figure_style = value
@@ -1318,7 +1320,7 @@ class SmartFigure:
 
     def _reset_stylable_elements_to_default(self) -> None:
         style_name = self._figure_style
-        if style_name == "default":
+        if style_name == INHERIT:
             style_name = get_default_style()
         try:
             defaults = FileLoader(style_name).load()
@@ -1329,7 +1331,7 @@ class SmartFigure:
             object_type = type(element).__name__
             for property_ in defaults.get(object_type, {}):
                 if hasattr(element, property_):
-                    setattr(element, property_, "default")
+                    setattr(element, property_, INHERIT)
 
     def _iter_all_plottables_recursive(self) -> Iterator[Plottable]:
         if self._mode == "leaf":
@@ -1943,7 +1945,7 @@ class SmartFigure:
         figure style, parameters and matplotlib figure and calls the :meth:`~graphinglib.SmartFigure._prepare_figure`
         method.
         """
-        if self._figure_style == "default":
+        if self._figure_style == INHERIT:
             self._figure_style = get_default_style()
         try:
             file_loader = FileLoader(self._figure_style)
@@ -2710,7 +2712,7 @@ class SmartFigure:
             "format", lambda le: f"{le})"
         )(letter)
         reflabel_params = {
-            k: v for k, v in self._reference_labels_params.items() if v != "default"
+            k: v for k, v in self._reference_labels_params.items() if v != INHERIT
         }
         target.text(
             x=0,
@@ -2844,11 +2846,7 @@ class SmartFigure:
         for try_i in range(2):
             try:
                 for property_, value in vars(element).items():
-                    if (
-                        (type(value) is str)
-                        and (value == "default")
-                        and not (property_ == "_figure_style")
-                    ):
+                    if is_inherit(value) and not (property_ == "_figure_style"):
                         params_to_reset.append(property_)
                         default_value = self._default_params[object_type][property_]
                         setattr(element, property_, default_value)
@@ -2880,7 +2878,7 @@ class SmartFigure:
         method.
         """
         for param in params_to_reset:
-            setattr(element, param, "default")
+            setattr(element, param, INHERIT)
 
     def _fill_in_rc_params(self, is_matplotlib_style: bool = False) -> None:
         """
@@ -3299,10 +3297,10 @@ class SmartFigure:
         visible_y: bool = True,
         which_x: Literal["major", "minor", "both"] = "both",
         which_y: Literal["major", "minor", "both"] = "both",
-        color: str | Literal["default"] = "default",
-        alpha: float | Literal["default"] = "default",
-        line_style: str | Literal["default"] = "default",
-        line_width: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
     ) -> Self:
         """
         Sets the grid parameters for the figure.
@@ -3342,10 +3340,10 @@ class SmartFigure:
             self._grid.clear()
             self._user_rc_dict.update(
                 {
-                    "grid.color": "default",
-                    "grid.alpha": "default",
-                    "grid.linestyle": "default",
-                    "grid.linewidth": "default",
+                    "grid.color": Inherit,
+                    "grid.alpha": Inherit,
+                    "grid.linestyle": Inherit,
+                    "grid.linewidth": Inherit,
                 }
             )
 
@@ -3362,7 +3360,7 @@ class SmartFigure:
             "grid.linestyle": line_style,
             "grid.linewidth": line_width,
         }
-        rc_params_dict = {k: v for k, v in rc_params_dict.items() if v != "default"}
+        rc_params_dict = {k: v for k, v in rc_params_dict.items() if v != INHERIT}
         self.set_rc_params(rc_params_dict)
         return self
 
@@ -3480,10 +3478,10 @@ class SmartFigure:
     def set_reference_labels_params(
         self,
         reset: bool = False,
-        color: str | Literal["default"] | None = None,
+        color: str | Inherit | None = None,
         start_index: int | None = None,
-        font_size: float | Literal["default"] | None = None,
-        font_weight: str | Literal["default"] | None = None,
+        font_size: float | Inherit | None = None,
+        font_weight: str | Inherit | None = None,
         format: Callable = None,
     ) -> Self:
         """
@@ -3495,15 +3493,15 @@ class SmartFigure:
             If ``True``, resets all previously set reference label parameters to their default values before applying
             the new parameters.
             Defaults to ``False``.
-        color : str | Literal["default"], optional
+        color : str | Inherit, optional
             The color of the reference labels. If ``"default"``, the color is set according to the text color of other
             text in the figure.
         start_index : int, optional
             Starting index for the reference labels. This allows to customize the starting label, for example, to start
             labeling from "b)" instead of "a)" by giving ``start_index = 1``.
-        font_size : float | Literal["default"], optional
+        font_size : float | Inherit, optional
             The font size of the reference labels.
-        font_weight : str | Literal["default"], optional
+        font_weight : str | Inherit, optional
             The font weight of the reference labels.
         format : Callable, optional
             A callable function to format the reference labels. By default, the reference labels are formatted as a),
@@ -3815,7 +3813,7 @@ class SmartFigureWCS(SmartFigure):
         num_cols: int = 1,
         x_label: str | None = None,
         y_label: str | None = None,
-        size: tuple[float, float] | Literal["default"] = "default",
+        size: tuple[float, float] | Inherit = INHERIT,
         title: str | None = None,
         x_lim: ListOrItem[tuple[float, float] | None] = None,
         y_lim: ListOrItem[tuple[float, float] | None] = None,
@@ -3848,7 +3846,7 @@ class SmartFigureWCS(SmartFigure):
         show_legend: ListOrItem[bool] = True,
         twin_x_axis: SmartTwinAxis | None = None,
         twin_y_axis: SmartTwinAxis | None = None,
-        figure_style: str = "default",
+        figure_style: str | Inherit = INHERIT,
         elements: Plottable
         | Iterable[Plottable | SmartFigure | None]
         | Iterable[Iterable[Plottable | None]] = [],
@@ -4265,10 +4263,10 @@ class SmartFigureWCS(SmartFigure):
         self,
         visible_x: bool = True,
         visible_y: bool = True,
-        color: str | Literal["default"] = "default",
-        alpha: float | Literal["default"] = "default",
-        line_style: str | Literal["default"] = "default",
-        line_width: float | Literal["default"] = "default",
+        color: str | Inherit = INHERIT,
+        alpha: float | Inherit = INHERIT,
+        line_style: str | Inherit = INHERIT,
+        line_width: float | Inherit = INHERIT,
     ) -> Self:
         """
         Sets the grid parameters for the figure.
@@ -4540,7 +4538,7 @@ class SmartTwinAxis:
         cycle_colors: list[str],
         is_y: bool,
         z_order: int,
-        figure_style: str,
+        figure_style: str | Inherit,
     ) -> tuple[list[str], list[Any]]:
         """
         Prepares the twin axis to be displayed.
@@ -4558,7 +4556,7 @@ class SmartTwinAxis:
         z_order : int
             The z-order for the elements plotted on the twin axis. This is used to ensure that the elements on the twin
             axis are drawn above the elements of the original axis.
-        figure_style : str
+        figure_style : str | Inherit
             The figure style to use for the twin axis. This is used for the
             :meth:`~graphinglib.SmartTwinAxis._fill_in_missing_params` method.
 
@@ -4718,7 +4716,7 @@ class SmartTwinAxis:
             )
 
     def _fill_in_missing_params(
-        self, element: SmartFigure | Plottable, figure_style: str
+        self, element: SmartFigure | Plottable, figure_style: str | Inherit
     ) -> list[str]:
         """
         Fills in the missing parameters for a :class:`~graphinglib.Plottable` from the parent's ``figure_style``.
@@ -4728,11 +4726,7 @@ class SmartTwinAxis:
         for try_i in range(2):
             try:
                 for property_, value in vars(element).items():
-                    if (
-                        (type(value) is str)
-                        and (value == "default")
-                        and not (property_ == "_figure_style")
-                    ):
+                    if is_inherit(value) and not (property_ == "_figure_style"):
                         params_to_reset.append(property_)
                         default_value = self._default_params[object_type][property_]
                         setattr(element, property_, default_value)
@@ -4764,7 +4758,7 @@ class SmartTwinAxis:
         method.
         """
         for param in params_to_reset:
-            setattr(element, param, "default")
+            setattr(element, param, INHERIT)
 
     def set_rc_params(
         self,

--- a/unit_testing/data_plotting_1d_test.py
+++ b/unit_testing/data_plotting_1d_test.py
@@ -1,6 +1,7 @@
 import unittest
 from random import random
 
+from graphinglib import INHERIT
 from matplotlib.collections import PathCollection
 from matplotlib.colors import to_hex, to_rgba
 from matplotlib.pyplot import close, subplots
@@ -24,7 +25,7 @@ class TestCurve(unittest.TestCase):
         self.assertIsInstance(self.testCurve._y_data, list | ndarray)
 
     def test_default_value(self):
-        self.assertEqual(self.testCurve._line_width, "default")
+        self.assertEqual(self.testCurve._line_width, INHERIT)
 
     def test_color_is_str(self):
         self.assertIsInstance(self.testCurve._color, str)
@@ -376,8 +377,14 @@ class TestScatter(unittest.TestCase):
         self.assertIsInstance(self.testScatter._x_data, list | ndarray)
 
     def test_color_is_str(self):
-        self.assertIsInstance(self.testScatter._face_color, str)
-        self.assertIsInstance(self.testScatter._edge_color, str)
+        self.assertTrue(
+            self.testScatter._face_color is INHERIT
+            or isinstance(self.testScatter._face_color, str)
+        )
+        self.assertTrue(
+            self.testScatter._edge_color is INHERIT
+            or isinstance(self.testScatter._edge_color, str)
+        )
 
     def test_label_is_str(self):
         self.assertIsInstance(self.testScatter._label, str)
@@ -938,10 +945,10 @@ class TestHistogram(unittest.TestCase):
         self.assertEqual(self.testHist._bins, 20)
 
     def test_alpha_is_default(self):
-        self.assertEqual(self.testHist._alpha, "default")
+        self.assertEqual(self.testHist._alpha, INHERIT)
 
     def test_hist_type_is_str(self):
-        self.assertEqual(self.testHist._hist_type, "default")
+        self.assertEqual(self.testHist._hist_type, INHERIT)
 
     def test_plot_residuals_from_fit(self):
         curve = Curve.from_function(lambda x: x**2, 0, 1)

--- a/unit_testing/figure_test.py
+++ b/unit_testing/figure_test.py
@@ -1,5 +1,7 @@
 import unittest
 
+from graphinglib import INHERIT
+
 from matplotlib import pyplot as plt
 from numpy import linspace, pi, sin
 
@@ -108,10 +110,10 @@ class TestFigure(unittest.TestCase):
         self.assertTrue(a_figure._show_grid)
 
     def test_element_defaults_are_reset(self):
-        self.testCurve._line_width = "default"
+        self.testCurve._line_width = INHERIT
         self.testFigure.add_elements(self.testCurve)
         self.testFigure._prepare_figure()
-        self.assertEqual(self.testCurve._line_width, "default")
+        self.assertEqual(self.testCurve._line_width, INHERIT)
         self.testFigure._fill_in_missing_params(self.testCurve)
         self.assertEqual(self.testCurve._line_width, 2)
         plt.close("all")

--- a/unit_testing/graph_elements_test.py
+++ b/unit_testing/graph_elements_test.py
@@ -1,5 +1,6 @@
 import unittest
 
+from graphinglib import INHERIT
 from matplotlib import pyplot as plt
 from matplotlib.colors import to_rgba
 from numpy import ndarray
@@ -29,10 +30,16 @@ class TestHlines(unittest.TestCase):
         self.assertIsInstance(self.testHlines._x_min, list | ndarray | float | int)
 
     def test_colors_is_str_list_or_none(self):
-        self.assertIsInstance(self.testHlines._colors, list | str | None)
+        self.assertTrue(
+            self.testHlines._colors is INHERIT
+            or isinstance(self.testHlines._colors, list | str | None)
+        )
 
     def test_linestyles_is_str_list_or_none(self):
-        self.assertIsInstance(self.testHlines._line_styles, list | str | None)
+        self.assertTrue(
+            self.testHlines._line_styles is INHERIT
+            or isinstance(self.testHlines._line_styles, list | str | None)
+        )
 
     def test_label_is_str(self):
         self.assertIsInstance(self.testHlines._label, str)
@@ -52,7 +59,7 @@ class TestHlines(unittest.TestCase):
         copied = self.testHlines.copy_with(colors="red")
         self.assertIsNot(copied, self.testHlines)
         self.assertEqual(copied.colors, "red")
-        self.assertEqual(self.testHlines.colors, "default")
+        self.assertEqual(self.testHlines.colors, INHERIT)
 
     def test_copy_with_rejects_private_property(self):
         with self.assertRaisesRegex(
@@ -168,10 +175,13 @@ class TestVlines(unittest.TestCase):
         self.assertEqual(self.testVlines._y_max, 1)
 
     def test_colors_is_default(self):
-        self.assertEqual(self.testVlines._colors, "default")
+        self.assertEqual(self.testVlines._colors, INHERIT)
 
     def test_linestyles_is_str_list_or_none(self):
-        self.assertIsInstance(self.testVlines._line_styles, list | str | None)
+        self.assertTrue(
+            self.testVlines._line_styles is INHERIT
+            or isinstance(self.testVlines._line_styles, list | str | None)
+        )
 
     def test_label_is_str(self):
         self.assertEqual(self.testVlines._label, "Test Vlines")
@@ -278,25 +288,25 @@ class TestPoint(unittest.TestCase):
         self.assertEqual(self.testPoint._alpha, 0.7)
 
     def test_colors_is_default(self):
-        self.assertEqual(self.testPoint._face_color, "default")
+        self.assertEqual(self.testPoint._face_color, INHERIT)
 
     def test_edge_color_is_default(self):
-        self.assertEqual(self.testPoint._edge_color, "default")
+        self.assertEqual(self.testPoint._edge_color, INHERIT)
 
     def test_marker_size_is_default(self):
-        self.assertEqual(self.testPoint._marker_size, "default")
+        self.assertEqual(self.testPoint._marker_size, INHERIT)
 
     def test_marker_style_is_default(self):
-        self.assertEqual(self.testPoint._marker_style, "default")
+        self.assertEqual(self.testPoint._marker_style, INHERIT)
 
     def test_edge_width_is_default(self):
-        self.assertEqual(self.testPoint._edge_width, "default")
+        self.assertEqual(self.testPoint._edge_width, INHERIT)
 
     def test_font_size_is_same_as_figure(self):
         self.assertEqual(self.testPoint._font_size, "same as figure")
 
     def test_text_color_is_default(self):
-        self.assertEqual(self.testPoint._text_color, "default")
+        self.assertEqual(self.testPoint._text_color, INHERIT)
 
     def test_h_align_is_left(self):
         self.assertEqual(self.testPoint._h_align, "left")

--- a/unit_testing/shapes_test.py
+++ b/unit_testing/shapes_test.py
@@ -299,7 +299,15 @@ class TestArrow(unittest.TestCase):
         self.assertEqual(shrinkedB[1], 3.4)
 
     def test_styles(self):
-        valid_styles: list[ArrowStyle] = ["->", "-|>", "-[", "]->", "simple", "fancy", "wedge"]
+        valid_styles: list[ArrowStyle] = [
+            "->",
+            "-|>",
+            "-[",
+            "]->",
+            "simple",
+            "fancy",
+            "wedge",
+        ]
         for style in valid_styles:
             arrow = Arrow(
                 pointA=(0, 0),

--- a/unit_testing/shapes_test.py
+++ b/unit_testing/shapes_test.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Literal
 
 import numpy as np
 from matplotlib import pyplot as plt
@@ -6,6 +7,8 @@ from matplotlib.colors import to_rgba
 
 from graphinglib.data_plotting_1d import Curve
 from graphinglib.shapes import Arrow, Circle, Ellipse, Line, Polygon, Rectangle
+
+ArrowStyle = Literal["->", "-|>", "-[", "]->", "simple", "fancy", "wedge"]
 
 
 class TestCircle(unittest.TestCase):
@@ -296,7 +299,7 @@ class TestArrow(unittest.TestCase):
         self.assertEqual(shrinkedB[1], 3.4)
 
     def test_styles(self):
-        valid_styles = ["->", "-|>", "-[", "]->", "simple", "fancy", "wedge"]
+        valid_styles: list[ArrowStyle] = ["->", "-|>", "-[", "]->", "simple", "fancy", "wedge"]
         for style in valid_styles:
             arrow = Arrow(
                 pointA=(0, 0),
@@ -319,7 +322,7 @@ class TestArrow(unittest.TestCase):
 
         # Check errors at plotting time
         _, ax = plt.subplots()
-        valid_two_sided_styles = ["->", "-|>", "-["]
+        valid_two_sided_styles: list[Literal["->", "-|>", "-["]] = ["->", "-|>", "-["]
         for style in valid_two_sided_styles:
             arrow = Arrow(
                 pointA=(0, 0),

--- a/unit_testing/smart_figure_test.py
+++ b/unit_testing/smart_figure_test.py
@@ -2,6 +2,8 @@ import os
 import unittest
 import warnings
 
+from graphinglib import INHERIT
+
 from matplotlib import use as matplotlib_use
 
 matplotlib_use("Agg")  # Use non-GUI backend for tests
@@ -89,8 +91,8 @@ class SmartFigurePropertyMixin:
 
         with self.assertRaises(TypeError):
             self.fig.figure_style = 123
-        self.fig.figure_style = "default"
-        self.assertEqual(self.fig.figure_style, "default")
+        self.fig.figure_style = INHERIT
+        self.assertEqual(self.fig.figure_style, INHERIT)
 
         with self.assertRaises(TypeError):
             self.fig.annotations = "not_a_list"
@@ -183,7 +185,7 @@ class TestSmartFigureLeaf(unittest.TestCase, SmartFigurePropertyMixin):
     def test_init_defaults(self):
         self.assertEqual(self.fig.num_rows, 1)
         self.assertEqual(self.fig.num_cols, 1)
-        self.assertEqual(self.fig.figure_style, "default")
+        self.assertEqual(self.fig.figure_style, INHERIT)
         self.assertEqual(len(self.fig), 0)
 
     def test_init_custom_args(self):
@@ -1102,7 +1104,7 @@ class TestSmartTwinAxis(unittest.TestCase):
         self.assertEqual(a_curve._line_width, 3)
 
     def test_element_defaults_are_reset(self):
-        self.curve1._line_width = "default"
+        self.curve1._line_width = INHERIT
         self.twin_axis.add_elements(self.curve1)
         self.twin_axis._default_params = FileLoader("plain").load()
         self.twin_axis._prepare_twin_axis(
@@ -1111,11 +1113,11 @@ class TestSmartTwinAxis(unittest.TestCase):
             plt.rcParams["axes.prop_cycle"].by_key()["color"],
             True,
             0,
-            "default",
+            INHERIT,
         )
-        self.assertEqual(self.curve1._line_width, "default")
+        self.assertEqual(self.curve1._line_width, INHERIT)
         self.twin_axis._default_params = self.plainDefaults
-        self.twin_axis._fill_in_missing_params(self.curve1, "default")
+        self.twin_axis._fill_in_missing_params(self.curve1, INHERIT)
         self.assertEqual(self.curve1._line_width, 2)
         plt.close("all")
 


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->

Closes issue #659.
```py
Literal["default"] = "default"
```
was replaced by
```py
Inherit = INHERIT
```
An example in context:
```py
    def __init__(
        self,
        x_center: float,
        y_center: float,
        radius: float,
        fill: bool | Inherit = INHERIT,
        fill_color: str | Inherit = INHERIT,
        edge_color: str | Inherit = INHERIT,
        line_width: float | Inherit = INHERIT,
        line_style: str | Inherit = INHERIT,
        fill_alpha: float | Inherit = INHERIT,
        number_of_points: int = 100,
    ):
        ...
```

This is made possible by the inherit.py file:
```py
from typing import TypeGuard


class Inherit:
    __slots__ = ()

    def __repr__(self) -> str:
        return "Inherit"

    __str__ = __repr__

    def __copy__(self) -> "Inherit":
        return self

    def __deepcopy__(self, memo: dict[int, object]) -> "Inherit":
        return self


INHERIT = Inherit()


def is_inherit(value: object) -> TypeGuard[Inherit]:
    return value is INHERIT

```

On an unrelated note, I didn't know about `TypeGuard`. Might be useful to strengthen GL's typing which is currently completely chaotic.

## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [x] Units tests have been run and/or modified and/or added
- [N/A] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [x] If new files have been added, make sure they aren't excluded by .gitignore
- [x] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/latest/contributing/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [ ] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request).
- [x] Links to the related issue (#....)
