### PR TITLE
Fix Heatmap dropping axis range

### DIFF
--- a/graphinglib/data_plotting_2d.py
+++ b/graphinglib/data_plotting_2d.py
@@ -41,8 +41,10 @@ class Heatmap(Plottable2D):
         Image to display. If an array of values is given, the 2D array will be interpreted as the values of the image.
         If a str if given, the corresponding file will be read as an image.
     x_axis_range, y_axis_range : tuple[float, float], optional
-        The range of x and y values used for the axes as tuples containing the start and end of the range. These values
-        are ignored when ``x_mesh`` and ``y_mesh`` are provided.
+        The range of x and y values used for the axes as tuples containing the start and end of the range. These
+        values are ignored when ``x_mesh`` and ``y_mesh`` are provided. ``x_axis_range`` and ``y_axis_range`` can be
+        set independently of one another; the axis left unset defaults to pixel-index coordinates based on the shape
+        of ``image``.
     x_mesh, y_mesh : ArrayLike, optional
         Mesh grids defining the coordinates of the heatmap values. When provided, the heatmap is plotted using
         ``pcolormesh`` instead of ``imshow``.
@@ -111,7 +113,9 @@ class Heatmap(Plottable2D):
             image. If a str if given, the corresponding file will be read as an image.
         x_axis_range, y_axis_range : tuple[float, float], optional
             The range of x and y values used for the axes as tuples containing the start and end of the range. These
-            values are ignored when ``x_mesh`` and ``y_mesh`` are provided.
+            values are ignored when ``x_mesh`` and ``y_mesh`` are provided. ``x_axis_range`` and ``y_axis_range`` can
+            be set independently of one another; the axis left unset defaults to pixel-index coordinates based on
+            the shape of ``image``.
         x_mesh, y_mesh : ArrayLike, optional
             Mesh grids defining the coordinates of the heatmap values. When provided, the heatmap is plotted using
             ``pcolormesh`` instead of ``imshow``.
@@ -461,9 +465,26 @@ class Heatmap(Plottable2D):
 
     @property
     def _xy_range(self) -> Optional[tuple[float, float, float, float]]:
-        if self._x_axis_range is not None and self._y_axis_range is not None:
-            return self._x_axis_range + self._y_axis_range
-        return None
+        if self._x_axis_range is None and self._y_axis_range is None:
+            return None
+        num_rows, num_cols = self._image.shape[:2]
+        x_range = (
+            self._x_axis_range
+            if self._x_axis_range is not None
+            else (-0.5, num_cols - 0.5)
+        )
+        if self._y_axis_range is not None:
+            y_range = self._y_axis_range
+        elif self._origin_position == "lower":
+            y_range = (-0.5, num_rows - 0.5)
+        else:
+            y_range = (num_rows - 0.5, -0.5)
+        return (
+            float(x_range[0]),
+            float(x_range[1]),
+            float(y_range[0]),
+            float(y_range[1]),
+        )
 
     def copy(self) -> Self:
         """

--- a/unit_testing/data_plotting_2d_test.py
+++ b/unit_testing/data_plotting_2d_test.py
@@ -37,6 +37,59 @@ class TestHeatmap(unittest.TestCase):
             (min(array_of_data.flatten()), max(array_of_data.flatten())),
         )
 
+    def test_only_x_axis_range_set(self):
+        array_of_data = np.random.rand(10, 10)
+        heatmap = Heatmap(
+            image=array_of_data,
+            x_axis_range=(0, 10),
+            color_map="viridis",
+            show_color_bar=False,
+            aspect_ratio="auto",
+            origin_position="upper",
+            interpolation="nearest",
+        )
+        fig, ax = plt.subplots()
+        heatmap._plot_element(ax, 0)
+        self.assertEqual(ax.get_xlim(), (0, 10))
+        self.assertEqual(ax.get_ylim(), (9.5, -0.5))
+
+    def test_only_y_axis_range_set(self):
+        array_of_data = np.random.rand(10, 10)
+        heatmap = Heatmap(
+            image=array_of_data,
+            y_axis_range=(0, 10),
+            color_map="viridis",
+            show_color_bar=False,
+            aspect_ratio="auto",
+            origin_position="upper",
+            interpolation="nearest",
+        )
+        fig, ax = plt.subplots()
+        heatmap._plot_element(ax, 0)
+        self.assertEqual(ax.get_xlim(), (-0.5, 9.5))
+        self.assertEqual(ax.get_ylim(), (0, 10))
+
+    def test_only_x_axis_range_set_origin_lower(self):
+        array_of_data = np.random.rand(10, 10)
+        heatmap = Heatmap(
+            image=array_of_data,
+            x_axis_range=(0, 10),
+            color_map="viridis",
+            show_color_bar=False,
+            aspect_ratio="auto",
+            origin_position="lower",
+            interpolation="nearest",
+        )
+        fig, ax = plt.subplots()
+        heatmap._plot_element(ax, 0)
+        self.assertEqual(ax.get_xlim(), (0, 10))
+        self.assertEqual(ax.get_ylim(), (-0.5, 9.5))
+
+    def test_xy_range_none_when_no_ranges_set(self):
+        array_of_data = np.random.rand(10, 10)
+        heatmap = Heatmap(image=array_of_data)
+        self.assertIsNone(heatmap._xy_range)
+
     def test_from_function(self):
         heatmap = Heatmap.from_function(
             func=lambda x, y: np.sin(x) + np.cos(y),


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->

Closes issue #683. In Heatmap, `_xy_range` required both ranges to be non-None, setting just one was silently ignored. Now each axis is resolved independently, with a fall back to matplotlib's default pixel-index for the unset axis.

## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [N/A] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/latest/contributing/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [x] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request).
- [x] Links to the related issue (#....)
