### PR TITLE
Fixed bug where nearest interpolation didnt snap x value

### DIFF
--- a/docs/release_notes/upcoming_changes/686.bugfix.rst
+++ b/docs/release_notes/upcoming_changes/686.bugfix.rst
@@ -1,0 +1,3 @@
+Fix incorrect x/y snapping for nearest/previous/next interpolation
+------------------------------------------------------------------
+Fixed a bug where `Curve` and `Scatter` methods that locate a point on the curve (`get_coordinates_at_x`, `create_point_at_x`, `get_coordinates_at_y`, `create_points_at_y`) would snap y value but not x value when using the `"nearest"`, `"previous"`, or `"next"` interpolation methods.

--- a/graphinglib/data_plotting_1d.py
+++ b/graphinglib/data_plotting_1d.py
@@ -24,6 +24,8 @@ try:
 except ImportError:
     from typing_extensions import Self
 
+_SNAPPING_INTERPOLATION_METHODS = frozenset({"nearest", "previous", "next"})
+
 
 @runtime_checkable
 class Fit(Protocol):
@@ -802,6 +804,10 @@ class Curve(Plottable1D, MathematicalObject):
 
             .. seealso:: `scipy.interpolate.interp1d <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html>`_
 
+            For ``"nearest"``, ``"previous"``, and ``"next"``, the returned coordinates snap to an
+            actual data point instead of interpolating; for every other kind, the returned x is the
+            same as the queried ``x``.
+
             Defaults to "linear".
 
         Returns
@@ -809,6 +815,12 @@ class Curve(Plottable1D, MathematicalObject):
         tuple[float, float]
             The coordinates of the curve at the given x value.
         """
+        if interpolation_method in _SNAPPING_INTERPOLATION_METHODS:
+            idx_interp = interp1d(
+                self._x_data, np.arange(len(self._x_data)), kind=interpolation_method
+            )
+            idx = int(round(float(idx_interp(x))))
+            return (float(self._x_data[idx]), float(self._y_data[idx]))
         return (
             x,
             float(interp1d(self._x_data, self._y_data, kind=interpolation_method)(x)),
@@ -837,6 +849,10 @@ class Curve(Plottable1D, MathematicalObject):
             The type of interpolation to be used, as defined in ``scipy.interpolate.interp1d``.
 
             .. seealso:: `scipy.interpolate.interp1d <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html>`_
+
+            For ``"nearest"``, ``"previous"``, and ``"next"``, the returned point snaps to an
+            actual data point instead of interpolating; for every other kind, the point's x is the
+            same as the queried ``x``.
 
             Defaults to "linear".
         label : str, optional
@@ -877,9 +893,10 @@ class Curve(Plottable1D, MathematicalObject):
         :class:`~graphinglib.graph_elements.Point`
             The point on the curve at the given x value.
         """
+        x_val, y_val = self.get_coordinates_at_x(x, interpolation_method)
         point = Point(
-            x,
-            self.get_coordinates_at_x(x, interpolation_method)[1],
+            x_val,
+            y_val,
             label=label,
             face_color=face_color,
             edge_color=edge_color,
@@ -908,6 +925,10 @@ class Curve(Plottable1D, MathematicalObject):
 
             .. seealso:: `scipy.interpolate.interp1d <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html>`_
 
+            For ``"nearest"``, ``"previous"``, and ``"next"``, the returned coordinates snap to an
+            actual data point instead of interpolating; for every other kind, the returned y is the
+            same as the queried ``y``.
+
             Defaults to "linear".
 
         Returns
@@ -918,14 +939,17 @@ class Curve(Plottable1D, MathematicalObject):
         xs = self._x_data
         ys = self._y_data
         crossings = np.where(np.diff(np.sign(ys - y)))[0]
-        x_vals: list[float] = []
+        points: list[tuple[float, float]] = []
         for cross in crossings:
             x1, x2 = xs[cross], xs[cross + 1]
             y1, y2 = ys[cross], ys[cross + 1]
-            f = interp1d([y1, y2], [x1, x2], kind=interpolation_method)
-            x_val = f(y)
-            x_vals.append(float(x_val))
-        points = [(x_val, y) for x_val in x_vals]
+            if interpolation_method in _SNAPPING_INTERPOLATION_METHODS:
+                idx_interp = interp1d([y1, y2], [0, 1], kind=interpolation_method)
+                idx = int(round(float(idx_interp(y))))
+                points.append((float((x1, x2)[idx]), float((y1, y2)[idx])))
+            else:
+                f = interp1d([y1, y2], [x1, x2], kind=interpolation_method)
+                points.append((float(f(y)), y))
         return points
 
     def create_points_at_y(
@@ -952,6 +976,10 @@ class Curve(Plottable1D, MathematicalObject):
             The type of interpolation to be used, as defined in ``scipy.interpolate.interp1d``.
 
             .. seealso:: `scipy.interpolate.interp1d <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html>`_
+
+            For ``"nearest"``, ``"previous"``, and ``"next"``, the returned points snap to actual
+            data points instead of interpolating; for every other kind, the points' y is the same
+            as the queried ``y``.
 
             Defaults to "linear".
         label : str, optional
@@ -2592,6 +2620,10 @@ class Scatter(Plottable1D, MathematicalObject):
 
             .. seealso:: `scipy.interpolate.interp1d <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html>`_
 
+            For ``"nearest"``, ``"previous"``, and ``"next"``, the returned coordinates snap to an
+            actual data point instead of interpolating; for every other kind, the returned x is the
+            same as the queried ``x``.
+
             Defaults to "linear".
 
         Returns
@@ -2599,6 +2631,12 @@ class Scatter(Plottable1D, MathematicalObject):
         tuple[float, float]
             The coordinates of the point on the curve at the given x value.
         """
+        if interpolation_method in _SNAPPING_INTERPOLATION_METHODS:
+            idx_interp = interp1d(
+                self._x_data, np.arange(len(self._x_data)), kind=interpolation_method
+            )
+            idx = int(round(float(idx_interp(x))))
+            return (float(self._x_data[idx]), float(self._y_data[idx]))
         return (
             x,
             float(interp1d(self._x_data, self._y_data, kind=interpolation_method)(x)),
@@ -2627,6 +2665,10 @@ class Scatter(Plottable1D, MathematicalObject):
             The type of interpolation to be used, as defined in ``scipy.interpolate.interp1d``.
 
             .. seealso:: `scipy.interpolate.interp1d <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html>`_
+
+            For ``"nearest"``, ``"previous"``, and ``"next"``, the returned point snaps to an
+            actual data point instead of interpolating; for every other kind, the point's x is the
+            same as the queried ``x``.
 
             Defaults to "linear".
         label : str, optional
@@ -2667,9 +2709,10 @@ class Scatter(Plottable1D, MathematicalObject):
         :class:`~graphinglib.graph_elements.Point`
             The Point on the curve at the given x value.
         """
+        x_val, y_val = self.get_coordinates_at_x(x, interpolation_method)
         point = Point(
-            x,
-            self.get_coordinates_at_x(x, interpolation_method)[1],
+            x_val,
+            y_val,
             label=label,
             face_color=face_color,
             edge_color=edge_color,
@@ -2698,6 +2741,10 @@ class Scatter(Plottable1D, MathematicalObject):
 
             .. seealso:: `scipy.interpolate.interp1d <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html>`_
 
+            For ``"nearest"``, ``"previous"``, and ``"next"``, the returned coordinates snap to an
+            actual data point instead of interpolating; for every other kind, the returned y is the
+            same as the queried ``y``.
+
             Defaults to "linear".
 
         Returns
@@ -2709,14 +2756,17 @@ class Scatter(Plottable1D, MathematicalObject):
         ys = self._y_data
         assert isinstance(xs, np.ndarray) and isinstance(ys, np.ndarray)
         crossings = np.where(np.diff(np.sign(ys - y)))[0]
-        x_vals: list[float] = []
+        points: list[tuple[float, float]] = []
         for cross in crossings:
             x1, x2 = xs[cross], xs[cross + 1]
             y1, y2 = ys[cross], ys[cross + 1]
-            f = interp1d([y1, y2], [x1, x2], kind=interpolation_method)
-            x_val = f(y)
-            x_vals.append(float(x_val))
-        points = [(x_val, y) for x_val in x_vals]
+            if interpolation_method in _SNAPPING_INTERPOLATION_METHODS:
+                idx_interp = interp1d([y1, y2], [0, 1], kind=interpolation_method)
+                idx = int(round(float(idx_interp(y))))
+                points.append((float((x1, x2)[idx]), float((y1, y2)[idx])))
+            else:
+                f = interp1d([y1, y2], [x1, x2], kind=interpolation_method)
+                points.append((float(f(y)), y))
         return points
 
     def create_points_at_y(
@@ -2743,6 +2793,10 @@ class Scatter(Plottable1D, MathematicalObject):
             The type of interpolation to be used, as defined in ``scipy.interpolate.interp1d``.
 
             .. seealso:: `scipy.interpolate.interp1d <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp1d.html>`_
+
+            For ``"nearest"``, ``"previous"``, and ``"next"``, the returned points snap to actual
+            data points instead of interpolating; for every other kind, the points' y is the same
+            as the queried ``y``.
 
             Defaults to "linear".
         label : str, optional

--- a/unit_testing/data_plotting_1d_test.py
+++ b/unit_testing/data_plotting_1d_test.py
@@ -90,6 +90,22 @@ class TestCurve(unittest.TestCase):
             self.assertEqual(point._y, 0)
             self.assertAlmostEqual(point._x, i * pi, places=3)
 
+    def test_snapping_interpolation_methods(self):
+        curve = Curve([0, 1, 2, 3], [0, 10, 20, 30])
+        expected = {"nearest": (1, 10), "previous": (1, 10), "next": (2, 20)}
+        for method, (x, y) in expected.items():
+            with self.subTest(method=method):
+                self.assertEqual(
+                    curve.get_coordinates_at_x(1.4, interpolation_method=method),
+                    (x, y),
+                )
+        point = curve.create_point_at_x(1.4, interpolation_method="nearest")
+        self.assertEqual((point._x, point._y), (1, 10))
+        self.assertEqual(
+            curve.get_coordinates_at_y(15, interpolation_method="nearest"), [(1, 10)]
+        )
+        self.assertEqual(curve.get_coordinates_at_x(1.4)[0], 1.4)
+
     def test_curve_is_plotted(self):
         x = linspace(0, 3 * pi, 200)
         self.testCurve = Curve(
@@ -446,6 +462,23 @@ class TestScatter(unittest.TestCase):
         for i, point in enumerate(points):
             self.assertEqual(point._y, 0)
             self.assertAlmostEqual(point._x, i * pi, places=3)
+
+    def test_snapping_interpolation_methods(self):
+        scatter = Scatter([0, 1, 2, 3], [0, 10, 20, 30])
+        expected = {"nearest": (1, 10), "previous": (1, 10), "next": (2, 20)}
+        for method, (x, y) in expected.items():
+            with self.subTest(method=method):
+                self.assertEqual(
+                    scatter.get_coordinates_at_x(1.4, interpolation_method=method),
+                    (x, y),
+                )
+        point = scatter.create_point_at_x(1.4, interpolation_method="nearest")
+        self.assertEqual((point._x, point._y), (1, 10))
+        self.assertEqual(
+            scatter.get_coordinates_at_y(15, interpolation_method="nearest"),
+            [(1, 10)],
+        )
+        self.assertEqual(scatter.get_coordinates_at_x(1.4)[0], 1.4)
 
     def test_scatter_is_plotted(self):
         x = linspace(0, 3 * pi, 200)


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->

Closes issue #630. See title. Kept the default as "linear", but might revisit this choice later. Also made this x snapping work for other snap interpolation methods like "previous" and "next".

## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [N/A] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/latest/contributing/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [x] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request).
- [x] Links to the related issue (#....)
