### PR TITLE
Fixed bugs in histogram and fits

### DIFF
--- a/docs/release_notes/upcoming_changes/688.bugfix.rst
+++ b/docs/release_notes/upcoming_changes/688.bugfix.rst
@@ -1,0 +1,3 @@
+Bugfixes for `Histogram` and the fit classes
+--------------------------------------------
+Fixed several bugs in `Histogram` and the fit classes: `Histogram` now draws its PDF mean and standard deviation lines on the correct axes in multi-panel figures, computes correct `bin_centers` for non-uniform bin edges, and keeps `bin_heights`/`bin_edges`/`bin_centers` consistent with the current `normalize` value. `FitFromSquareRoot.cov_matrix` and `.standard_deviation` no longer crash with a `RecursionError`, `str()` on a `FitFromFunction` no longer raises `NotImplementedError`, `get_Rsquared` now returns a well-defined value for constant data, and `FitFromGaussian`/`FitFromFOTF` fits are now bounded to keep `sigma`/`tau` positive instead of silently producing NaN curves.

--- a/graphinglib/data_plotting_1d.py
+++ b/graphinglib/data_plotting_1d.py
@@ -3205,6 +3205,9 @@ class Histogram(Plottable1D):
         self._normalize = normalize
         self._orientation = orientation
         self._show_params = show_params
+        self._histogram_cache: Optional[tuple[bool, tuple[np.ndarray, np.ndarray]]] = (
+            None
+        )
         self.data = np.asarray(data)
 
         self._show_pdf = False
@@ -3306,13 +3309,7 @@ class Histogram(Plottable1D):
         self._data = np.array(data)
         self._mean = np.mean(self._data)
         self._standard_deviation = np.std(self._data)
-        _parameters = np.histogram(self._data, bins=self._bins, density=self._normalize)
-        self._bin_heights, bin_edges = _parameters[0], _parameters[1]
-        bin_width = bin_edges[1] - bin_edges[0]
-        bin_centers = bin_edges[1:] - bin_width / 2
-        self._bin_width = bin_width
-        self._bin_centers = bin_centers
-        self._bin_edges = bin_edges
+        self._histogram_cache = None
 
     @property
     def bins(self) -> int:
@@ -3321,13 +3318,7 @@ class Histogram(Plottable1D):
     @bins.setter
     def bins(self, bins: int) -> None:
         self._bins = bins
-        _parameters = np.histogram(self._data, bins=self._bins, density=self._normalize)
-        self._bin_heights, bin_edges = _parameters[0], _parameters[1]
-        bin_width = bin_edges[1] - bin_edges[0]
-        bin_centers = bin_edges[1:] - bin_width / 2
-        self._bin_width = bin_width
-        self._bin_centers = bin_centers
-        self._bin_edges = bin_edges
+        self._histogram_cache = None
 
     @property
     def label(self) -> str:
@@ -3384,6 +3375,7 @@ class Histogram(Plottable1D):
     @normalize.setter
     def normalize(self, normalize: bool) -> None:
         self._normalize = normalize
+        self._histogram_cache = None
 
     @property
     def orientation(self) -> str:
@@ -3414,16 +3406,34 @@ class Histogram(Plottable1D):
         return self._mean, self._standard_deviation
 
     @property
-    def bin_heights(self) -> np.ndarray:
-        return self._bin_heights
+    def _resolved_normalize(self) -> bool:
+        return False if is_inherit(self._normalize) else bool(self._normalize)
+
+    def _compute_histogram(self) -> tuple[np.ndarray, np.ndarray]:
+        # The cache remembers which `density` value it was computed with, and is
+        # recomputed if that value has changed since. This is needed because some
+        # code (e.g. figure style resolution) changes `_normalize` without going
+        # through the `normalize` setter, so the setter alone can't clear the cache.
+        density = self._resolved_normalize
+        if self._histogram_cache is None or self._histogram_cache[0] != density:
+            self._histogram_cache = (
+                density,
+                np.histogram(self._data, bins=self._bins, density=density),
+            )
+        return self._histogram_cache[1]
 
     @property
-    def bin_centers(self) -> np.ndarray:
-        return self._bin_centers
+    def bin_heights(self) -> np.ndarray:
+        return self._compute_histogram()[0]
 
     @property
     def bin_edges(self) -> np.ndarray:
-        return self._bin_edges
+        return self._compute_histogram()[1]
+
+    @property
+    def bin_centers(self) -> np.ndarray:
+        edges = self.bin_edges
+        return (edges[:-1] + edges[1:]) / 2
 
     def __eq__(self, other: Self) -> bool:
         """
@@ -3486,7 +3496,9 @@ class Histogram(Plottable1D):
         The corresponding array of y values of the gaussian curve.
         """
         x = np.array(x)
-        return sum(self._bin_heights) * self._bin_width * self._normal_normalized(x)
+        bin_heights, bin_edges = self._compute_histogram()
+        total_area = np.sum(bin_heights * np.diff(bin_edges))
+        return total_area * self._normal_normalized(x)
 
     def add_pdf(
         self,
@@ -3569,6 +3581,7 @@ class Histogram(Plottable1D):
         """
         Plots the element in the specified axes.
         """
+        normalize_resolved = self._resolved_normalize
         params = {
             "facecolor": (
                 to_rgba(self._face_color, self._alpha)
@@ -3600,7 +3613,7 @@ class Histogram(Plottable1D):
             ),
             "histtype": self._hist_type,
             "linewidth": self._line_width,
-            "density": self._normalize,
+            "density": normalize_resolved,
             "orientation": self._orientation,
         }
         params = {k: v for k, v in params.items() if v != INHERIT}
@@ -3614,11 +3627,12 @@ class Histogram(Plottable1D):
         if self._show_pdf:
             normal = (
                 self._normal_normalized
-                if self._normalize
+                if normalize_resolved
                 else self._normal_not_normalized
             )
             num_of_points = 500
-            x_data = np.linspace(self._bin_edges[0], self._bin_edges[-1], num_of_points)
+            bin_edges = self.bin_edges
+            x_data = np.linspace(bin_edges[0], bin_edges[-1], num_of_points)
             y_data = normal(x_data)
             params = {
                 "color": self._pdf_curve_color,
@@ -3651,7 +3665,7 @@ class Histogram(Plottable1D):
 
                 # Plots std on the y-axis if "orientation" is "horizontal".
                 if self._orientation != "vertical":
-                    plt.hlines(
+                    axes.hlines(
                         [
                             self._mean - self._standard_deviation,
                             self._mean + self._standard_deviation,
@@ -3664,7 +3678,7 @@ class Histogram(Plottable1D):
                     )
 
                 else:
-                    plt.vlines(
+                    axes.vlines(
                         [
                             self._mean - self._standard_deviation,
                             self._mean + self._standard_deviation,
@@ -3683,7 +3697,7 @@ class Histogram(Plottable1D):
 
                 # Plots std on the y-axis if "orientation" is "horizontal".
                 if self._orientation != "vertical":
-                    plt.hlines(
+                    axes.hlines(
                         self._mean,
                         0,
                         curve_max_y,
@@ -3693,7 +3707,7 @@ class Histogram(Plottable1D):
                     )
 
                 else:
-                    plt.vlines(
+                    axes.vlines(
                         self._mean,
                         0,
                         curve_max_y,

--- a/graphinglib/fits.py
+++ b/graphinglib/fits.py
@@ -20,6 +20,22 @@ except ImportError:
     from typing_extensions import Self
 
 
+def _repair_positive_guess(
+    guesses: ArrayLike, index: int, number_of_parameters: int
+) -> np.ndarray:
+    """
+    Copies the initial guesses and forces the guess of a bounded parameter to be strictly positive.
+    """
+    guesses = np.array(guesses, dtype=float)
+    if guesses.shape != (number_of_parameters,):
+        raise ValueError(
+            f"Expected {number_of_parameters} initial guesses, "
+            f"but got an array of shape {guesses.shape}."
+        )
+    guesses[index] = max(abs(guesses[index]), 1e-10)
+    return guesses
+
+
 class GeneralFit(Curve):
     """
     Dummy class for curve fits. Defines the interface for all curve fits.
@@ -106,6 +122,9 @@ class GeneralFit(Curve):
         self._alpha = alpha
 
         self._function: Callable[[np.ndarray], np.ndarray]
+        self._parameters: np.ndarray
+        self._cov_matrix: np.ndarray
+        self._standard_deviation: np.ndarray
 
         self._setup_attributes()
 
@@ -143,6 +162,18 @@ class GeneralFit(Curve):
     @property
     def function(self) -> Callable[[np.ndarray], np.ndarray]:
         return self._function
+
+    @property
+    def parameters(self) -> np.ndarray:
+        return self._parameters
+
+    @property
+    def cov_matrix(self) -> np.ndarray:
+        return self._cov_matrix
+
+    @property
+    def standard_deviation(self) -> np.ndarray:
+        return self._standard_deviation
 
     def __str__(self) -> str:
         """
@@ -426,14 +457,17 @@ class GeneralFit(Curve):
         Rsquared : float
             :math:`R^2` value
         """
-        Rsquared = 1 - (
-            np.sum(self.get_residuals() ** 2)
-            / np.sum(
-                (self._curve_to_be_fit._y_data - np.mean(self._curve_to_be_fit._y_data))
-                ** 2
-            )
-        )
-        return Rsquared
+        y_data = self._curve_to_be_fit._y_data
+        total_variance = np.sum((y_data - np.mean(y_data)) ** 2)
+        if total_variance == 0:
+            # Scale the tolerance to the data's own magnitude, since comparing residuals
+            # to an absolute tolerance of 0 makes np.allclose's rtol term vanish. Only
+            # fall back to an absolute tolerance when the data is identically zero.
+            magnitude = np.max(np.abs(y_data))
+            scale = magnitude if magnitude > 0 else 1.0
+            is_exact_fit = np.allclose(self.get_residuals(), 0, atol=1e-8 * scale)
+            return 1.0 if is_exact_fit else float("nan")
+        return 1 - np.sum(self.get_residuals() ** 2) / total_variance
 
     def copy(self) -> Self:
         return deepcopy(self)
@@ -586,12 +620,8 @@ class FitFromPolynomial(GeneralFit):
         return self._coeffs
 
     @property
-    def cov_matrix(self) -> np.ndarray:
-        return self._cov_matrix
-
-    @property
-    def standard_deviation(self) -> np.ndarray:
-        return self._standard_deviation
+    def parameters(self) -> np.ndarray:
+        return self._coeffs
 
     def __str__(self) -> str:
         """
@@ -841,18 +871,6 @@ class FitFromSine(GeneralFit):
     def vertical_shift(self) -> float:
         return self._vertical_shift
 
-    @property
-    def cov_matrix(self) -> np.ndarray:
-        return self._cov_matrix
-
-    @property
-    def standard_deviation(self) -> np.ndarray:
-        return self._standard_deviation
-
-    @property
-    def parameters(self) -> np.ndarray:
-        return self._parameters
-
     def __str__(self) -> str:
         """
         Creates a string representation of the sine function.
@@ -1061,18 +1079,6 @@ class FitFromExponential(GeneralFit):
     @property
     def max_iterations(self) -> int:
         return self._max_iterations
-
-    @property
-    def parameters(self) -> np.ndarray:
-        return self._parameters
-
-    @property
-    def cov_matrix(self) -> np.ndarray:
-        return self._cov_matrix
-
-    @property
-    def standard_deviation(self) -> np.ndarray:
-        return self._standard_deviation
 
     def __str__(self) -> str:
         """
@@ -1300,19 +1306,13 @@ class FitFromGaussian(GeneralFit):
 
     @property
     def standard_deviation(self) -> float:
+        # Unlike the other fit classes, this is the fitted sigma of the gaussian itself,
+        # not the standard deviation of the fit parameters (see standard_deviation_of_fit_params).
         return self._standard_deviation
-
-    @property
-    def cov_matrix(self) -> np.ndarray:
-        return self._cov_matrix
 
     @property
     def standard_deviation_of_fit_params(self) -> np.ndarray:
         return self._standard_deviation_of_fit_params
-
-    @property
-    def parameters(self) -> np.ndarray:
-        return self._parameters
 
     def __str__(self) -> str:
         """
@@ -1324,12 +1324,18 @@ class FitFromGaussian(GeneralFit):
         """
         Calculates the parameters of the fit.
         """
+        guesses = self._guesses
+        if guesses is not None:
+            # The standard deviation guess must be positive to satisfy the fit's bounds,
+            # regardless of the sign the caller happened to guess.
+            guesses = _repair_positive_guess(guesses, index=2, number_of_parameters=3)
         self._parameters, self._cov_matrix = curve_fit(
             self._gaussian_func_template,
             self._curve_to_be_fit._x_data,
             self._curve_to_be_fit._y_data,
-            p0=self._guesses,
+            p0=guesses,
             maxfev=self._max_iterations,
+            bounds=([-np.inf, -np.inf, 1e-10], [np.inf, np.inf, np.inf]),
         )
         self._amplitude = self._parameters[0]
         self._mean = self._parameters[1]
@@ -1512,18 +1518,6 @@ class FitFromSquareRoot(GeneralFit):
     @property
     def max_iterations(self) -> int:
         return self._max_iterations
-
-    @property
-    def parameters(self) -> np.ndarray:
-        return self._parameters
-
-    @property
-    def cov_matrix(self) -> np.ndarray:
-        return self.cov_matrix
-
-    @property
-    def standard_deviation(self) -> np.ndarray:
-        return self.standard_deviation
 
     def __str__(self) -> str:
         """
@@ -1728,18 +1722,6 @@ class FitFromLog(GeneralFit):
     def max_iterations(self) -> int:
         return self._max_iterations
 
-    @property
-    def parameters(self) -> np.ndarray:
-        return self._parameters
-
-    @property
-    def cov_matrix(self) -> np.ndarray:
-        return self._cov_matrix
-
-    @property
-    def standard_deviation(self) -> np.ndarray:
-        return self._standard_deviation
-
     def __str__(self) -> str:
         """
         Creates a string representation of the logarithmic function.
@@ -1920,7 +1902,10 @@ class FitFromFunction(GeneralFit):
 
         self._calculate_parameters()
         self._function = self._get_function_with_params()
-        self._label = label
+        if label:
+            self._label = label + " : " + str(self)
+        else:
+            self._label = str(self)
         self._res_curves_to_be_plotted = False
         number_of_points = (
             len(self._curve_to_be_fit._x_data)
@@ -1940,17 +1925,11 @@ class FitFromFunction(GeneralFit):
     def max_iterations(self) -> int:
         return self._max_iterations
 
-    @property
-    def parameters(self) -> np.ndarray:
-        return self._parameters
-
-    @property
-    def cov_matrix(self) -> np.ndarray:
-        return self._cov_matrix
-
-    @property
-    def standard_deviation(self) -> np.ndarray:
-        return self._standard_deviation
+    def __str__(self) -> str:
+        """
+        Creates a string representation of the fitted function.
+        """
+        return f"Fit from function: {self._function_template.__name__}"
 
     def _calculate_parameters(self) -> None:
         """
@@ -2141,18 +2120,6 @@ class FitFromFOTF(GeneralFit):
     def time_constant(self) -> float:
         return self._time_constant
 
-    @property
-    def cov_matrix(self) -> np.ndarray:
-        return self._cov_matrix
-
-    @property
-    def standard_deviation(self) -> np.ndarray:
-        return self._standard_deviation
-
-    @property
-    def parameters(self) -> np.ndarray:
-        return self._parameters
-
     def __str__(self) -> str:
         """
         Creates a string representation of the first order transfer function.
@@ -2163,12 +2130,18 @@ class FitFromFOTF(GeneralFit):
         """
         Calculates the parameters of the fit.
         """
+        guesses = self._guesses
+        if guesses is not None:
+            # The time constant guess must be positive to satisfy the fit's bounds,
+            # regardless of the sign the caller happened to guess.
+            guesses = _repair_positive_guess(guesses, index=1, number_of_parameters=2)
         self._parameters, self._cov_matrix = curve_fit(
             self._fotf_func_template,
             self._curve_to_be_fit._x_data,
             self._curve_to_be_fit._y_data,
-            p0=self._guesses,
+            p0=guesses,
             maxfev=self._max_iterations,
+            bounds=([-np.inf, 1e-10], [np.inf, np.inf]),
         )
         self._gain = self._parameters[0]
         self._time_constant = self._parameters[1]

--- a/unit_testing/data_plotting_1d_test.py
+++ b/unit_testing/data_plotting_1d_test.py
@@ -4,8 +4,8 @@ from random import random
 from graphinglib import INHERIT
 from matplotlib.collections import PathCollection
 from matplotlib.colors import to_hex, to_rgba
-from matplotlib.pyplot import close, subplots
-from numpy import linspace, ndarray, pi, sin
+from matplotlib.pyplot import close, sca, subplots
+from numpy import allclose, array, linspace, ndarray, pi, sin
 
 from graphinglib.data_plotting_1d import Curve, Histogram, Scatter
 from graphinglib.figure import Figure
@@ -999,6 +999,54 @@ class TestHistogram(unittest.TestCase):
         self.assertEqual(hist_copy._alpha, self.testHist._alpha)
         self.assertEqual(hist_copy._hist_type, self.testHist._hist_type)
         self.assertListEqual(list(hist_copy._data), list(self.testHist._data))
+
+    def test_bin_centers_non_uniform_bins(self):
+        hist = Histogram(
+            [0.5, 1.5, 3, 3.5, 5, 7, 9],
+            bins=array([0, 1, 2, 4, 6, 10]),
+            normalize=False,
+        )
+        expected = (hist.bin_edges[:-1] + hist.bin_edges[1:]) / 2
+        self.assertTrue(allclose(hist.bin_centers, expected))
+
+    def test_bin_heights_default_to_raw_counts_when_normalize_unresolved(self):
+        hist = Histogram([random() for _ in range(100)], 10)
+        self.assertEqual(hist._normalize, INHERIT)
+        self.assertAlmostEqual(sum(hist.bin_heights), 100)
+
+    def test_bin_heights_not_stale_after_rendering(self):
+        # Regression test: rendering resolves `_normalize` by setting the private
+        # attribute directly (bypassing the `normalize` setter), which used to leave
+        # a stale density-normalized histogram cache behind after the post-render
+        # reset restored INHERIT.
+        hist = Histogram([random() for _ in range(100)], 10)
+        hist.add_pdf()
+        figure = Figure(figure_style="plain")
+        figure.add_elements(hist)
+        figure._prepare_figure()
+        close("all")
+        self.assertEqual(hist._normalize, INHERIT)
+        self.assertAlmostEqual(sum(hist.bin_heights), 100)
+
+    def test_pdf_mean_std_lines_use_correct_axes(self):
+        fig, (ax1, ax2) = subplots(1, 2)
+        sca(ax2)
+        hist = Histogram(
+            [random() for _ in range(100)],
+            10,
+            face_color="silver",
+            edge_color="k",
+            hist_type="stepfilled",
+            alpha=0.5,
+            line_width=1,
+            normalize=True,
+            orientation="vertical",
+            show_params=False,
+        )
+        hist.add_pdf(show_mean=True, show_std=True)
+        hist._plot_element(ax1, 0)
+        self.assertEqual(len(ax2.collections), 0)
+        self.assertEqual(len(ax1.collections), 2)
 
 
 if __name__ == "__main__":

--- a/unit_testing/fits_test.py
+++ b/unit_testing/fits_test.py
@@ -5,6 +5,7 @@ import numpy as np
 from graphinglib.data_plotting_1d import Curve, Scatter
 from graphinglib.fits import (
     FitFromExponential,
+    FitFromFOTF,
     FitFromFunction,
     FitFromGaussian,
     FitFromLog,
@@ -29,6 +30,14 @@ class TestFitFromPolynomial(unittest.TestCase):
     def test_first_degree_coeffs(self):
         self.assertListEqual(
             [round(i, 5) for i in list(self.fit_first_degree._coeffs)], [2, 3]
+        )
+
+    def test_parameters_property(self):
+        # Regression test: this used to raise AttributeError once `parameters` was
+        # centralized onto GeneralFit, since this class stores its fit output in
+        # `_coeffs`, not `_parameters`.
+        self.assertListEqual(
+            [round(i, 5) for i in list(self.fit_first_degree.parameters)], [2, 3]
         )
 
     def test_first_degree_cov(self):
@@ -141,6 +150,17 @@ class TestFitFromPolynomial(unittest.TestCase):
         )
         self.assertEqual(copy._color, self.fit_first_degree._color)
         self.assertEqual(copy._label, self.fit_first_degree._label)
+
+    def test_get_rsquared_perfect_fit(self):
+        self.assertAlmostEqual(self.fit_first_degree.get_Rsquared(), 1.0)
+
+    def test_get_rsquared_constant_data(self):
+        # Regression test: used to silently divide by zero (nan/inf with a RuntimeWarning)
+        # when the fitted data has zero variance.
+        x = np.linspace(-3, 3, 100)
+        flat_scatter = Scatter(x, np.full_like(x, 5.0), "k", "Flat")
+        flat_fit = FitFromPolynomial(flat_scatter, 0, "k", "Constant fit")
+        self.assertAlmostEqual(flat_fit.get_Rsquared(), 1.0)
 
 
 class TestFitFromSine(unittest.TestCase):
@@ -336,6 +356,15 @@ class TestFitFromGaussian(unittest.TestCase):
         self.assertIsInstance(self.fit._standard_deviation_of_fit_params, np.ndarray)
         self.assertEqual(self.fit._standard_deviation_of_fit_params.shape, (3,))
 
+    def test_negative_std_dev_guess_does_not_raise(self):
+        # Regression test: bounds=(...) added to keep standard_deviation positive used
+        # to reject any negative initial guess outright instead of just the fitted result.
+        guesses = np.array([5.0, 1.0, -1.0])
+        fit = FitFromGaussian(self.data, guesses=guesses)
+        self.assertAlmostEqual(fit.standard_deviation, 1, places=2)
+        # The caller's array must not be mutated by the guess repair.
+        self.assertListEqual(list(guesses), [5.0, 1.0, -1.0])
+
     def test_str(self):
         self.assertEqual(str(self.fit), r"$\mu = 1.000, \sigma = 1.000, A = 5.000$")
 
@@ -415,6 +444,16 @@ class TestFitFromSquareRoot(unittest.TestCase):
     def test_std_dev(self):
         self.assertIsInstance(self.fit._standard_deviation, np.ndarray)
         self.assertEqual(self.fit._standard_deviation.shape, (3,))
+
+    def test_cov_matrix_property(self):
+        # Regression test: this property used to recurse into itself infinitely.
+        self.assertIsInstance(self.fit.cov_matrix, np.ndarray)
+        self.assertEqual(self.fit.cov_matrix.shape, (3, 3))
+
+    def test_standard_deviation_property(self):
+        # Regression test: this property used to recurse into itself infinitely.
+        self.assertIsInstance(self.fit.standard_deviation, np.ndarray)
+        self.assertEqual(self.fit.standard_deviation.shape, (3,))
 
     def test_str(self):
         self.assertEqual(str(self.fit), "$3.000 \\sqrt{x + 4.000} + 5.000$")
@@ -569,6 +608,14 @@ class TestFitFromFunction(unittest.TestCase):
         self.assertIsInstance(self.fit._standard_deviation, np.ndarray)
         self.assertEqual(self.fit._standard_deviation.shape, (2,))
 
+    def test_str(self):
+        # Regression test: this used to raise NotImplementedError.
+        self.assertEqual(str(self.fit), "Fit from function: <lambda>")
+
+    def test_default_label(self):
+        # Regression test: this used to be the literal string "None".
+        self.assertEqual(self.fit.label, "Fit from function: <lambda>")
+
     def test_function(self):
         self.assertAlmostEqual(self.fit._function(1), 4, places=3)
 
@@ -607,6 +654,77 @@ class TestFitFromFunction(unittest.TestCase):
     def test_copy(self):
         copy = self.fit.copy()
         # check that all attributes are the same
+        self.assertEqual(list(copy._parameters), list(self.fit._parameters))
+        self.assertEqual(copy._cov_matrix.tolist(), self.fit._cov_matrix.tolist())
+        self.assertEqual(
+            copy._standard_deviation.tolist(),
+            self.fit._standard_deviation.tolist(),
+        )
+        self.assertEqual(copy._color, self.fit._color)
+        self.assertEqual(copy._label, self.fit._label)
+
+
+class TestFitFromFOTF(unittest.TestCase):
+    def setUp(self) -> None:
+        x = np.linspace(0, 20, 1000)
+        self.data = Scatter(x, 5 * (1 - np.exp(-x / 3)), "Data")
+        self.fit = FitFromFOTF(self.data, "FOTF fit")
+
+    def test_parameters(self):
+        rounded_params = [round(i, 3) for i in list(self.fit._parameters)]
+        self.assertListEqual(rounded_params, [5, 3])
+
+    def test_cov(self):
+        self.assertIsInstance(self.fit._cov_matrix, np.ndarray)
+        self.assertEqual(self.fit._cov_matrix.shape, (2, 2))
+
+    def test_std_dev(self):
+        self.assertIsInstance(self.fit._standard_deviation, np.ndarray)
+        self.assertEqual(self.fit._standard_deviation.shape, (2,))
+
+    def test_cov_matrix_property(self):
+        self.assertIsInstance(self.fit.cov_matrix, np.ndarray)
+        self.assertEqual(self.fit.cov_matrix.shape, (2, 2))
+
+    def test_standard_deviation_property(self):
+        self.assertIsInstance(self.fit.standard_deviation, np.ndarray)
+        self.assertEqual(self.fit.standard_deviation.shape, (2,))
+
+    def test_gain(self):
+        self.assertAlmostEqual(self.fit.gain, 5, places=3)
+
+    def test_time_constant(self):
+        self.assertAlmostEqual(self.fit.time_constant, 3, places=3)
+
+    def test_str(self):
+        self.assertEqual(str(self.fit), "$K = 5.000, \\tau = 3.000$")
+
+    def test_function(self):
+        self.assertAlmostEqual(self.fit._function(3), 3.161, places=3)
+
+    def test_get_coordinates_at_x(self):
+        self.assertAlmostEqual(self.fit.get_coordinates_at_x(3)[1], 3.161, places=3)
+
+    def test_create_point_at_x(self):
+        self.assertAlmostEqual(self.fit.create_point_at_x(3)._y, 3.161, places=3)
+
+    def test_get_derivative_curve(self):
+        self.assertIsInstance(self.fit.create_derivative_curve(), Curve)
+
+    def test_get_integral_curve(self):
+        self.assertIsInstance(self.fit.create_integral_curve(), Curve)
+
+    def test_negative_time_constant_guess_does_not_raise(self):
+        # Regression test: bounds=(...) added to keep time_constant positive used to
+        # reject any negative initial guess outright instead of just the fitted result.
+        guesses = np.array([5.0, -3.0])
+        fit = FitFromFOTF(self.data, guesses=guesses)
+        self.assertAlmostEqual(fit.time_constant, 3, places=3)
+        # The caller's array must not be mutated by the guess repair.
+        self.assertListEqual(list(guesses), [5.0, -3.0])
+
+    def test_copy(self):
+        copy = self.fit.copy()
         self.assertEqual(list(copy._parameters), list(self.fit._parameters))
         self.assertEqual(copy._cov_matrix.tolist(), self.fit._cov_matrix.tolist())
         self.assertEqual(


### PR DESCRIPTION
<!--
Thank you for your contribution and pull request. Please refer to the subsequent comments to format your PR. 
For further information, visit https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request.

We understand that PRs can sometimes be overwhelming. If you're uncertain about any of these steps,
don't hesitate to create the pull request anyway and leave a comment asking your questions.
-->

## PR summary
<!--
Please provide at least 1-2 sentences describing the pull request in detail
(What problem does it solve? How did you solve it?) and link to relevant issues and PRs.

Also please summarize the changes in the title and avoid non-descriptive titles such as
"Addresses issue #1234".
-->

**Histogram fixes**
- PDF overlay lines could land on the wrong subplot since they were plotted with plt. instead of with axes.
- Wrong bin_centers for non-uniform bins. The bin width was computed from the first bin only and reused for all of them, so every center after the first was wrong when passing an array of non-uniform bin edges
- Bin statistics could use the wrong normalize value. bin_heights/bin_edges/bin_centers were computed once at construction with density=self._normalize, at a point where normalize can still be INHERIT, so unset normalize behaved as True regardless of the style default
**Fit class fixes**
- FitFromSquareRoot.cov_matrix and .standard_deviation crashed with RecursionError — the properties returned themselves instead of the underlying attributes. Now they live once on GeneralFit instead of being copy-pasted into all 8 subclasses
- str() on a FitFromFunction raised NotImplementedError, and its default legend label was the literal string "None". It now formats as Fit from function: <name> like its siblings
- get_Rsquared() returned nan for constant data. Zero-variance data is now handled explicitly: 1.0 for an exact fit, nan otherwise
- FitFromGaussian/FitFromFOTF could converge to zero/negative sigma/tau, producing nan curves. Their curve_fit calls now bound these parameters to be strictly positive.

## PR checklist

<!-- Please check every step you've completed. Mark any non-applicable statement with [N/A]. -->

- [x] Units tests have been run and/or modified and/or added
- [x] Docstrings are complete
- [N/A] Any new dependencies have been added to pyproject.toml and requirements.txt (in docs folder)
- [N/A] If new files have been added, make sure they aren't excluded by .gitignore
- [N/A] Documentation has been updated (if applicable, see [Contributing to the documentation](https://www.graphinglib.org/latest/contributing/contributing.html#contributing-to-the-documentation) for details on how to make changes to the documentation)
- [x] If your changes modify the API, a short release note has been added to the ``docs/release_notes/upcoming_changes`` directory following the [Guidelines for submitting a pull request](https://www.graphinglib.org/latest/contributing/contributing.html#guidelines-for-submitting-a-pull-request).
- [N/A] Links to the related issue (#....)
